### PR TITLE
Image representation and loading into Spark

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+docs/_build/
+build/
+dist/

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,0 +1,4 @@
+# An example MANIFEST file can be found at:
+# https://github.com/pypa/sampleproject/blob/master/MANIFEST.in
+# For more details about the MANIFEST file, you may read the docs at
+# https://docs.python.org/2/distutils/sourcedist.html#the-manifest-in-template

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,8 @@
+# This file should list any python package dependencies.
+h5py==2.7.0
+keras==2.0.4
+nose==1.3.7  # for testing
+numpy==1.11.2
+pillow==4.1.1
+tensorflow==1.1.0
+pygments==2.2.0

--- a/python/run-tests.sh
+++ b/python/run-tests.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Return on any failure
+set -e
+
+# assumes run from python/ directory
+if [ -z "$SPARK_HOME" ]; then
+    echo 'You need to set $SPARK_HOME to run these tests.' >&2
+    exit 1
+fi
+
+# Honor the choice of python driver
+if [ -z "$PYSPARK_PYTHON" ]; then
+    PYSPARK_PYTHON=`which python`
+fi
+# Override the python driver version as well to make sure we are in sync in the tests.
+export PYSPARK_DRIVER_PYTHON=$PYSPARK_PYTHON
+python_major=$($PYSPARK_PYTHON -c 'import sys; print(".".join(map(str, sys.version_info[:1])))')
+
+echo $pyver
+
+LIBS=""
+for lib in "$SPARK_HOME/python/lib"/*zip ; do
+  LIBS=$LIBS:$lib
+done
+
+# The current directory of the script.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+a=( ${SCALA_VERSION//./ } )
+scala_version_major_minor="${a[0]}.${a[1]}"
+echo "List of assembly jars found, the last one will be used:"
+assembly_path="$DIR/../target/scala-$scala_version_major_minor"
+echo `ls $assembly_path/sparkdl-assembly*.jar`
+JAR_PATH=""
+for assembly in $assembly_path/sparkdl-assembly*.jar ; do
+  JAR_PATH=$assembly
+done
+
+# python dir ($DIR) should be before assembly so dev changes can be picked up.
+export PYTHONPATH=$PYTHONPATH:$DIR
+export PYTHONPATH=$PYTHONPATH:$assembly   # same $assembly used for the JAR_PATH above
+export PYTHONPATH=$PYTHONPATH:$SPARK_HOME/python:$LIBS:.
+
+# This will be used when starting pyspark.
+export PYSPARK_SUBMIT_ARGS="--driver-memory 4g --executor-memory 4g --jars $JAR_PATH pyspark-shell"
+
+
+# Run test suites
+
+# TODO: make sure travis has the right version of nose
+if [ $# -gt 0 ]; then
+  if [ "$1" != "" ]; then
+    noseOptionsArr="$DIR/tests/$1"
+  fi
+else
+  # add all python files in the test dir recursively
+  noseOptionsArr="$(find $DIR/tests -type f | grep "\.py" | grep -v "\.pyc" | grep -v "\.py~" | grep -v "__init__.py")"
+fi
+for noseOptions in $noseOptionsArr
+do
+  echo "============= Running the tests in: $noseOptions ============="
+  # The grep below is a horrible hack for spark 1.x: we manually remove some log lines to stay below the 4MB log limit on Travis.
+  $PYSPARK_DRIVER_PYTHON -m "nose" -v --exe "$noseOptions" 2>&1 | grep -vE "INFO (ParquetOutputFormat|SparkContext|ContextCleaner|ShuffleBlockFetcherIterator|MapOutputTrackerMaster|TaskSetManager|Executor|MemoryStore|CacheManager|BlockManager|DAGScheduler|PythonRDD|TaskSchedulerImpl|ZippedPartitionsRDD2)";
+
+  # Exit immediately if the tests fail.
+  # Since we pipe to remove the output, we need to use some horrible BASH features:
+  # http://stackoverflow.com/questions/1221833/bash-pipe-output-and-capture-exit-status
+  test ${PIPESTATUS[0]} -eq 0 || exit 1;
+done
+
+
+# Run doc tests
+
+cd "$DIR"
+
+#$PYSPARK_PYTHON -u ./sparkdl/ourpythonfilewheneverwehaveone.py "$@"

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,0 +1,2 @@
+# This file contains the default option values to be used during setup. An
+# example can be found at https://github.com/pypa/sampleproject/blob/master/setup.cfg

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,2 @@
+# Your python setup file. An example can be found at:
+# https://github.com/pypa/sampleproject/blob/master/setup.py

--- a/python/spark-package-deps.txt
+++ b/python/spark-package-deps.txt
@@ -1,0 +1,3 @@
+# This file should list any spark package dependencies as:
+# :package_name==:version   e.g. databricks/spark-csv==0.1
+databricks/tensorframes==0.2.8

--- a/python/sparkdl/__init__.py
+++ b/python/sparkdl/__init__.py
@@ -1,0 +1,28 @@
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from .image.imageIO import imgSchema, imageType, readImages
+from .transformers.keras_image import KerasImageFileTransformer
+from .transformers.named_image import DeepImagePredictor, DeepImageFeaturizer
+from .transformers.tf_image import TFImageTransformer
+from .transformers.utils import imageInputPlaceholder, stripAndFreezeGraph
+
+# TODO: separate out images & transformers
+__all__ = [
+    'imgSchema', 'imageType', 'readImages',
+    'TFImageTransformer',
+    'DeepImagePredictor', 'DeepImageFeaturizer',
+    'KerasImageFileTransformer',
+    'imageInputPlaceholder', 'stripAndFreezeGraph']

--- a/python/sparkdl/image/__init__.py
+++ b/python/sparkdl/image/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/sparkdl/image/imageIO.py
+++ b/python/sparkdl/image/imageIO.py
@@ -1,0 +1,191 @@
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from io import BytesIO
+from collections import namedtuple
+from warnings import warn
+
+# 3rd party
+import numpy as np
+from PIL import Image
+
+# pyspark
+from pyspark import Row
+from pyspark.sql.types import (BinaryType, IntegerType, StringType, StructField, StructType)
+from pyspark.sql.functions import udf
+
+
+imgSchema = StructType([StructField("mode", StringType(), False),
+                        StructField("height", IntegerType(), False),
+                        StructField("width", IntegerType(), False),
+                        StructField("nChannels", IntegerType(), False),
+                        StructField("data", BinaryType(), False)])
+
+
+# ImageType class for holding metadata about images stored in DataFrames.
+# fields:
+#   nChannels - number of channels in the image
+#   dtype - data type of the image's "data" Column, sorted as a numpy compatible string.
+#   channelContent - info about the contents of each channel currently only "I" (intensity) and
+#     "RGB" are supported for 1 and 3 channel data respectively.
+#   pilMode - The mode that should be used to convert to a PIL image.
+#   sparkMode - Unique identifier string used in spark image representation.
+ImageType = namedtuple("ImageType", ["nChannels",
+                                     "dtype",
+                                     "channelContent",
+                                     "pilMode",
+                                     "sparkMode",
+                                     ])
+class SparkMode(object):
+    RGB = "RGB"
+    FLOAT32 = "float32"
+    RGB_FLOAT32 = "RGB-float32"
+
+supportedImageTypes = [
+    ImageType(3, "uint8", "RGB", "RGB", SparkMode.RGB),
+    ImageType(1, "float32", "I", "F", SparkMode.FLOAT32),
+    ImageType(3, "float32", "RGB", None, SparkMode.RGB_FLOAT32),
+]
+pilModeLookup = {t.pilMode: t for t in supportedImageTypes
+                 if t.pilMode is not None}
+sparkModeLookup = {t.sparkMode: t for t in supportedImageTypes}
+
+
+def imageToStruct(imgArray, imageType=None):
+    """
+    Create spark image row from numpy array and (optional) imageType.
+
+    to_image_udf = udf(arrayToImageRow, imgSchema)
+    df.withColumn("output_img", to_image_udf(df["np_arr_col"])
+
+    :param imgArray: ndarray, image data.
+    :param imageType: ImageType, type of the image. If unspecified, it is inferred from imgArray.
+    :return: list, image as a DataFrame Row compatible list.
+    """
+    arr = imgArray
+    if imageType is None:
+        # Sometimes tensors have a leading "batch-size" dimension. Assume to be 1 if it exists.
+        if len(imgArray.shape) == 4:
+            if imgArray.shape[0] != 1:
+                raise ValueError("The first dimension of a 4-d image array is expected to be 1.")
+            arr = imgArray.reshape(imgArray.shape[1:])
+
+        sparkMode = _arrayToSparkMode(arr)
+        if sparkMode in [SparkMode.FLOAT32, SparkMode.RGB_FLOAT32]:
+            arr = arr.astype(np.float32)
+    else:
+        sparkMode = imageType.sparkMode
+
+    height, width, nChannels = arr.shape
+    data = bytearray(arr.tobytes())
+    return Row(mode=sparkMode, height=height, width=width, nChannels=nChannels, data=data)
+
+
+def imageType(imageRow):
+    """
+    Get type information about the image.
+
+    :param imageRow: spark image row.
+    :return: ImageType
+    """
+    return sparkModeLookup[imageRow.mode]
+
+
+def imageToArray(imageRow):
+    """
+    Convert an image to a numpy array.
+
+    :param imageRow: Row, must use imgSchema.
+    :return: ndarray, image data.
+    """
+    imType = imageType(imageRow)
+    shape = (imageRow.height, imageRow.width, imageRow.nChannels)
+    return np.ndarray(shape, imType.dtype, imageRow.data)
+
+
+def _arrayToSparkMode(arr):
+    assert len(arr.shape) == 3, "Array should have 3 dimensions but has shape {}".format(arr.shape)
+    num_channels = arr.shape[2]
+    if num_channels == 1:
+        if arr.dtype not in [np.float16, np.float32, np.float64]:
+            raise ValueError("incompatible dtype (%s) for numpy array for float32 mode" %
+                             arr.dtype.string)
+        return SparkMode.FLOAT32
+    elif num_channels != 3:
+        raise ValueError("number of channels of the input array (%d) is not supported" %
+                         num_channels)
+    elif arr.dtype == np.uint8:
+        return SparkMode.RGB
+    elif arr.dtype in [np.float16, np.float32, np.float64]:
+        return SparkMode.RGB_FLOAT32
+    else:
+        raise ValueError("did not find a sparkMode for the given array with num_channels = %d " +
+                         "and dtype %s" % (num_channels, arr.dtype.string))
+
+
+def _decodeImage(imageData):
+    """
+    Decode compressed image data into a DataFrame image row.
+
+    :param imageData: (bytes, bytearray) compressed image data in PIL compatible format.
+    :return: Row, decoded image.
+    """
+    try:
+        img = Image.open(BytesIO(imageData))
+    except IOError:
+        return None
+
+    if img.mode in pilModeLookup:
+        mode = pilModeLookup[img.mode]
+    else:
+        msg = "We don't currently support images with mode: {mode}"
+        warn(msg.format(mode=img.mode))
+        return None
+    imgArray = np.asarray(img)
+    image = imageToStruct(imgArray, mode)
+    return image
+
+# Creating a UDF on import can cause SparkContext issues sometimes.
+# decodeImage = udf(_decodeImage, imgSchema)
+
+def filesToDF(sc, path, numPartitions=None):
+    """
+    Read files from a directory to a DataFrame.
+
+    :param sc: SparkContext.
+    :param path: str, path to files.
+    :param numPartition: int, number or partitions to use for reading files.
+    :return: DataFrame, with columns: (filePath: str, fileData: BinaryType)
+    """
+    numPartitions = numPartitions or sc.defaultParallelism
+    schema = StructType([StructField("filePath", StringType(), False),
+                         StructField("fileData", BinaryType(), False)])
+    rdd = sc.binaryFiles(path, minPartitions=numPartitions).repartition(numPartitions)
+    rdd = rdd.map(lambda x: (x[0], bytearray(x[1])))
+    return rdd.toDF(schema)
+
+
+def readImages(sc, imageDirectory, numPartition=None):
+    """
+    Read a directory of images (or a single image) into a DataFrame.
+
+    :param sc: spark context
+    :param imageDirectory: str, file path.
+    :param numPartition: int, number or partitions to use for reading files.
+    :return: DataFrame, with columns: (filepath: str, image: imgSchema).
+    """
+    decodeImage = udf(_decodeImage, imgSchema)
+    imageData = filesToDF(sc, imageDirectory, numPartitions=numPartition)
+    return imageData.select("filePath", decodeImage("fileData").alias("image"))

--- a/python/sparkdl/sparkdl.py
+++ b/python/sparkdl/sparkdl.py
@@ -1,0 +1,15 @@
+#
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/sparkdl/utils.py
+++ b/python/sparkdl/utils.py
@@ -1,0 +1,57 @@
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Internal utilities module.
+
+This should not get exposed outside.
+"""
+import logging
+
+from pyspark import SparkContext
+from pyspark.sql.column import Column
+
+ENTRYPOINT_CLASSNAME = "com.databricks.sparkdl.python.PythonInterface"
+
+logger = logging.getLogger('sparkdl')
+
+def _java_api_sql(javaClassName, sqlCtx = None):
+    """
+    Loads the PythonInterface object (lazily, because the spark context needs to be initialized
+    first).
+
+    WARNING: this works by setting a hidden variable called SQLContext._active_sql_context
+    """
+    # I suspect the SQL context is doing crazy things at import, because I was
+    # experiencing some issues here.
+    from pyspark.sql import SQLContext
+    _sc = SparkContext._active_spark_context
+    logger.info("Spark context = " + str(_sc))
+    if sqlCtx is None:
+        _sql = SQLContext._instantiatedContext
+    else:
+        _sql = sqlCtx
+    _jvm = _sc._jvm
+    # You cannot simply call the creation of the the class on the _jvm due to classloader issues
+    # with Py4J.
+    return _jvm.Thread.currentThread().getContextClassLoader().loadClass(javaClassName) \
+        .newInstance().sqlContext(_sql._ssql_ctx)
+
+def _api():
+    return _java_api_sql(ENTRYPOINT_CLASSNAME)
+
+def list_to_vector_udf(col):
+    jc = _api().listToVectorFunction(col._jc)
+    return Column(jc)

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/tests/image/__init__.py
+++ b/python/tests/image/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/tests/image/test_imageIO.py
+++ b/python/tests/image/test_imageIO.py
@@ -1,0 +1,139 @@
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from io import BytesIO
+
+# 3rd party
+import numpy as np
+import PIL.Image
+
+# pyspark
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, udf
+from pyspark.sql.types import BinaryType, StringType, StructField, StructType
+
+from sparkdl.image import imageIO
+from ..tests import SparkDLTestCase
+
+# Create dome fake image data to work with
+def create_image_data():
+    # Random image-like data
+    array = np.random.randint(0, 256, (10, 11, 3), 'uint8')
+
+    # Compress as png
+    imgFile = BytesIO()
+    PIL.Image.fromarray(array).save(imgFile, 'png')
+    imgFile.seek(0)
+
+    # Get Png data as stream
+    pngData = imgFile.read()
+    return array, pngData
+
+array, pngData = create_image_data()
+
+
+class BinaryFilesMock(object):
+
+    defaultParallelism = 4
+
+    def __init__(self, sc):
+        self.sc = sc
+
+    def binaryFiles(self, path, minPartitions=None):
+        imagesData = [["file/path", pngData],
+                      ["another/file/path", pngData],
+                      ["bad/image", b"badImageData"]
+                      ]
+        rdd = self.sc.parallelize(imagesData)
+        if minPartitions is not None:
+            rdd = rdd.repartition(minPartitions)
+        return rdd
+
+
+class TestReadImages(SparkDLTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestReadImages, cls).setUpClass()
+        cls.binaryFilesMock = BinaryFilesMock(cls.sc)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestReadImages, cls).tearDownClass()
+        cls.binaryFilesMock = None
+
+    def test_decodeImage(self):
+        badImg = imageIO._decodeImage(b"xxx")
+        self.assertIsNone(badImg)
+        imgRow = imageIO._decodeImage(pngData)
+        self.assertIsNotNone(imgRow)
+        self.assertEqual(len(imgRow), len(imageIO.imgSchema.names))
+        for n in imageIO.imgSchema.names:
+            imgRow[n]
+
+    def test_image_round_trip(self):
+        # Test round trip: array -> png -> sparkImg -> array
+        binarySchema = StructType([StructField("data", BinaryType(), False)])
+        df = self.session.createDataFrame([[bytearray(pngData)]], binarySchema)
+
+        # Convert to images
+        decImg = udf(imageIO._decodeImage, imageIO.imgSchema)
+        imageDF = df.select(decImg("data").alias("image"))
+        row = imageDF.first()
+
+        testArray = imageIO.imageToArray(row.image)
+        self.assertEqual(testArray.shape, array.shape)
+        self.assertEqual(testArray.dtype, array.dtype)
+        self.assertTrue(np.all(array == testArray))
+
+    def test_readImages(self):
+        # Test that reading
+        imageDF = imageIO.readImages(self.binaryFilesMock, "some/path")
+        self.assertTrue("image" in imageDF.schema.names)
+        self.assertTrue("filePath" in imageDF.schema.names)
+
+        # The DF should have 2 images and 1 null.
+        self.assertEqual(imageDF.count(), 3)
+        validImages = imageDF.filter(col("image").isNotNull())
+        self.assertEqual(validImages.count(), 2)
+
+        img = validImages.first().image
+        self.assertEqual(img.height, array.shape[0])
+        self.assertEqual(img.width, array.shape[1])
+        self.assertEqual(imageIO.imageType(img).nChannels, array.shape[2])
+        self.assertEqual(img.data, array.tobytes())
+
+    def test_silly_udf(self):
+        def silly(imgRow):
+            imType = imageIO.imageType(imgRow)
+            array = imageIO.imageToArray(imgRow)
+            return imageIO.imageToStruct(array, imType)
+        silly_udf = udf(silly, imageIO.imgSchema)
+
+        df = imageIO.readImages(self.binaryFilesMock, "path")
+        df = df.filter(col('image').isNotNull()).withColumn("test", silly_udf('image'))
+        self.assertEqual(df.first().test.data, array.tobytes())
+        df.printSchema()
+
+    def test_filesTODF(self):
+        df = imageIO.filesToDF(self.binaryFilesMock, "path", 217)
+        self.assertEqual(df.rdd.getNumPartitions(), 217)
+        df.schema.fields[0].dataType == StringType()
+        df.schema.fields[0].dataType == BinaryType()
+        first = df.first()
+        self.assertTrue(hasattr(first, "filePath"))
+        self.assertEqual(type(first.fileData), bytearray)
+
+
+# TODO: make unit tests for arrayToImageRow on arrays of varying shapes, channels, dtypes.

--- a/python/tests/tests.py
+++ b/python/tests/tests.py
@@ -1,0 +1,49 @@
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
+
+from pyspark import SparkContext
+from pyspark.sql import SQLContext
+from pyspark.sql import SparkSession
+
+
+class SparkDLTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sc = SparkContext('local[4]', cls.__name__)
+        cls.sql = SQLContext(cls.sc)
+        cls.session = SparkSession.builder.getOrCreate()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.session.stop()
+        cls.session = None
+        cls.sc.stop()
+        cls.sc = None
+        cls.sql = None
+
+    def assertDfHasCols(self, df, cols = []):
+        map(lambda c: self.assertIn(c, df.columns), cols)


### PR DESCRIPTION
This PR introduces the new image representation (SpImage) for Spark as well as loading images into the format using Spark and converting from numpy arrays. These APIs are available in Python (no Scala coverage).

This is @MrBago's PR but he is busy right now so I'm sending the PR.