### PR TITLE
Better testing

### DIFF
--- a/python/run-tests.sh
+++ b/python/run-tests.sh
@@ -56,7 +56,7 @@ for lib in "$SPARK_HOME/python/lib"/*zip ; do
 done
 
 # The current directory of the script.
-DIR=$( dirname "${BASH_SOURCE[0]}" )
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 a=( ${SCALA_VERSION//./ } )
 scala_version_major_minor="${a[0]}.${a[1]}"


### PR DESCRIPTION
run_tests.sh can now take a file or a directory to test.

There are 3 ways to use the updated test script.
1) To run all the python tests for this package, from the `spark-deep-learning` directory call `python/run-tests.sh`. eg:
```
~/spark-deep-learning$ python/run-tests.sh
```

2) To run a single test file, pass that file to `run-tests.sh`, eg:
```
~/spark-deep-learning$ python/run-tests.sh python/tests/transformers/named_image_test.py
```

3) To run all tests in a single directory, pass that directory to `run-tests.sh`, eg:
```
~/spark-deep-learning$ python/run-tests.sh python/tests/transformers
```