### PR TITLE
Building UDFs from TensorFlow Graphs

### DIFF
--- a/python/sparkdl/__init__.py
+++ b/python/sparkdl/__init__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-from .graph_builder import GraphBuilderSession, GraphFunction
 from .image.imageIO import imgSchema, imageType, readImages
 from .transformers.keras_image import KerasImageFileTransformer
 from .transformers.named_image import DeepImagePredictor, DeepImageFeaturizer
@@ -25,6 +24,5 @@ __all__ = [
     'imgSchema', 'imageType', 'readImages',
     'TFImageTransformer',
     'DeepImagePredictor', 'DeepImageFeaturizer',
-    "GraphBuilderSession", "GraphFunction",
     'KerasImageFileTransformer',
     'imageInputPlaceholder', 'stripAndFreezeGraph']

--- a/python/sparkdl/__init__.py
+++ b/python/sparkdl/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+from .graph_builder import GraphBuilderSession, GraphFunction
 from .image.imageIO import imgSchema, imageType, readImages
 from .transformers.keras_image import KerasImageFileTransformer
 from .transformers.named_image import DeepImagePredictor, DeepImageFeaturizer
@@ -24,5 +25,6 @@ __all__ = [
     'imgSchema', 'imageType', 'readImages',
     'TFImageTransformer',
     'DeepImagePredictor', 'DeepImageFeaturizer',
+    "GraphBuilderSession", "GraphFunction",
     'KerasImageFileTransformer',
     'imageInputPlaceholder', 'stripAndFreezeGraph']

--- a/python/sparkdl/graph_builder.py
+++ b/python/sparkdl/graph_builder.py
@@ -1,0 +1,329 @@
+#
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import joblib as jl
+import logging
+from pathlib import Path
+import shutil
+import six
+from tempfile import mkdtemp
+import webbrowser
+
+import keras.backend as K
+import tensorflow as tf
+import tensorframes.core as tfrm
+
+from .utils import JVMAPI
+
+logger = logging.getLogger('sparkdl')
+
+class GraphBuilder(object):
+    """ 
+    Building TensorFlow graph and export as either UDF or GraphFunction
+    
+    This is a thin layer on top of `tf.Session`.
+    """
+
+    def __init__(self, graph):
+        assert isinstance(graph, tf.Graph)
+        self.sess = tf.Session(graph=graph)
+        self.graph = graph
+
+    def get_shape(self, tnsr_or_name):
+        _shape = self.get_tensor(tnsr_or_name).get_shape().as_list()
+        return [-1 if x is None else x for x in _shape]
+    
+    def get_op(self, tfobj_or_name):
+        if isinstance(tfobj_or_name, tf.Operation):
+            return tfobj_or_name
+        name = tfobj_or_name
+        if isinstance(tfobj_or_name, tf.Tensor):
+            name = tfobj_or_name.name
+        if not isinstance(name, six.string_types):
+            raise TypeError('invalid op request for {} of {}'.format(name, type(name)))
+        name = name.split(":")[0]
+        op = self.graph.get_operation_by_name(name)
+        assert op is not None, \
+            'cannot locate op {} in current graph'.format(name)
+        return op        
+
+    def get_tensor(self, tfobj_or_name):
+        if isinstance(tfobj_or_name, tf.Tensor):
+            return tfobj_or_name
+        name = tfobj_or_name
+        if isinstance(tfobj_or_name, tf.Operation):
+            name = tfobj_or_name.name
+        if not isinstance(name, six.string_types):
+            raise TypeError('invalid tensor request for {} of {}'.format(name, type(name)))
+        name_parts = name.split(":")
+        if len(name_parts) < 2:
+            name += ":0"
+        tnsr = self.graph.get_tensor_by_name(name)
+        assert tnsr is not None, \
+            'cannot locate tensor {} in current graph'.format(name)
+        return tnsr
+
+    def op_name(self, tfobj_or_name):
+        return self.get_op(tfobj_or_name).name
+
+    def tensor_name(self, tfobj_or_name):
+        return self.get_tensor(tfobj_or_name).name
+
+    def valid_output(self, tfobj_or_name):
+        return self.op_name(tfobj_or_name)
+
+    def valid_input(self, tfobj_or_name):
+        name = self.op_name(tfobj_or_name)
+        op = self.graph.get_operation_by_name(name)
+        assert 'Placeholder' == op.type, \
+            ('input must be Placeholder, but get', op.type)
+        return name
+
+    def show_tf_graph(self, max_const_size=32):
+        """ Visualize TensorFlow graph.
+        """
+        _tfb_url_prefix = "https://tensorboard.appspot.com"
+        _tfb_url = "{}/tf-graph-basic.build.html".format(_tfb_url_prefix)
+
+        def strip_consts(gdef, max_const_size=32):
+            """Strip large constant values from graph_def."""
+            strip_def = tf.GraphDef()
+            for n0 in gdef.node:
+                n = strip_def.node.add()  # pylint: disable=E1101
+                n.MergeFrom(n0)
+                if n.op == 'Const':
+                    tensor = n.attr['value'].tensor
+                    nbytes = len(tensor.tensor_content)
+                    if nbytes > max_const_size:
+                        tensor.tensor_content = str.encode("<stripped {} bytes>".format(nbytes))
+            return strip_def
+
+        strip_def = strip_consts(self.graph.as_graph_def(), max_const_size)
+        code = """
+            <script>
+              function load() {{
+                document.getElementById("{id}").pbtxt = {data};
+              }}
+            </script>
+            <link rel="import" href="{tfb}" onload=load()>
+            <div style="height:600px">
+              <tf-graph-basic id="{id}"></tf-graph-basic>
+            </div>
+        """.format(data=repr(str(strip_def)), 
+                   id='gfn-sess-graph',
+                   tfb=_tfb_url)
+
+        # Construct the graph def board and open it
+        fp_out = Path.cwd() / "graph_def.html"
+        with open(str(fp_out), 'wb') as fout:
+            try:
+                fout.write(code)
+            except TypeError:
+                fout.write(code.encode('utf8'))
+        print("file @", str(fp_out))
+        webbrowser.get("chrome").open("file://{}".format(str(fp_out)))
+
+
+    def asUDF(self, udf_name, fetches, feed_dict=None, blocked=False, register=True):
+        """ 
+        Make the TensorFlow graph as a SQL UDF 
+
+        :param udf_name: str, name of the SQL UDF 
+        :param fetches: list, output tensors of the graph
+        :param feed_dict: dict, a dictionary that maps graph elements to input values
+        :param blocked: bool, whether the TensorFrame execution should be blocked based or row based
+        :param register: bool, whether this UDF should be registered
+        :return: JVM function handle object
+        """ 
+        # pylint: disable=W0212
+        # TODO: work with registered expansions
+        jvm_builder = JVMAPI.for_class("com.databricks.sparkdl.PythonModelFactory")
+        tfrm._add_graph(self.graph, jvm_builder)
+
+        fetch_names = [self.tensor_name(tnsr) for tnsr in fetches]
+        fetch_shapes = [self.get_shape(tnsr) for tnsr in fetches]
+        placeholder_names = []
+        placeholder_shapes = []
+
+        for node in self.graph.as_graph_def(add_shapes=True).node:
+            if len(node.input) == 0 and str(node.op) == 'Placeholder':
+                tnsr_name = self.tensor_name(node.name)
+                tnsr = self.graph.get_tensor_by_name(tnsr_name)
+                try:
+                    tnsr_shape = self.get_shape(tnsr)
+                    placeholder_names.append(tnsr_name)
+                    placeholder_shapes.append(tnsr_shape)
+                except ValueError:
+                    pass
+
+        jvm_builder.shape(fetch_names + placeholder_names, fetch_shapes + placeholder_shapes)
+        jvm_builder.fetches(fetch_names)
+        placeholder_op_names = [self.op_name(tnsr_name) for tnsr_name in placeholder_names]
+        tfrm._add_inputs(jvm_builder, feed_dict, placeholder_op_names)
+        
+        if register:
+            return jvm_builder.registerUDF(udf_name, blocked)
+        else:
+            return jvm_builder.makeUDF(udf_name, blocked)
+        
+    def asGraphFunction(self, inputs, outputs, strip_and_freeze=True):
+        """
+        Build a GraphFunction object
+
+        :param inputs: list, graph elements representing the inputs
+        :param outputs: list, graph elements representing the outputs
+        :param strip_and_freeze: bool, should we remove unused part of the graph and freee its values
+        """
+        if strip_and_freeze:
+            gdef = self.strip_and_freeze_until(outputs)
+        else:
+            gdef = self.graph.as_graph_def(add_shapes=True)
+        return GraphFunction(graph_def=gdef,
+                             input_names=[self.valid_input(i) for i in inputs],
+                             output_names=[self.valid_output(o) for o in outputs])
+
+    
+    def strip_and_freeze_until(self, fetches):
+        """
+        Converting all variables into constants
+        
+        :param fetches: list, graph elements representing the outputs of the graph
+        :return: GraphDef, the GraphDef object with cleanup procedure applied
+        """
+        gdef_frozen = tf.graph_util.convert_variables_to_constants(
+            self.sess, 
+            self.graph.as_graph_def(add_shapes=True),
+            [self.op_name(tnsr) for tnsr in fetches])
+        return gdef_frozen
+
+
+    def import_graph_function(self, gfn, input_map=None, name="GFN-IMPORT", **gdef_kargs):
+        """
+        Import a GraphFunction object into the current session
+        
+        :param gfn: GraphFunction, an object representing a TensorFlow graph and its inputs and outputs
+        :param input_map: dict, mapping from input names to existing graph elements 
+        :param name: str, the scope for all the variables in the GraphFunction's elements
+        :param gdef_kargs: other keyword elements for TensorFlow's `import_graph_def`
+        """
+        try:
+            del gdef_kargs["return_elements"]
+        except KeyError: 
+            pass
+        if input_map is not None:
+            assert set(input_map.keys()) <= set(gfn.input_names), \
+                "cannot locate provided input elements in the graph"
+
+        input_names = gfn.input_names
+        output_names = gfn.output_names
+        if name is not None:
+            name = name.strip()
+            if len(name) > 0:
+                output_names = [
+                    name + '/' + op_name for op_name in gfn.output_names]
+                input_names = [
+                    name + '/' + op_name for op_name in gfn.input_names]
+            
+        # When importing, provide the original output op names
+        tf.import_graph_def(gfn.graph_def,
+                            input_map=input_map,
+                            return_elements=gfn.output_names,
+                            name=name,
+                            **gdef_kargs)
+        feeds = list(map(self.get_tensor, input_names))
+        fetches = list(map(self.get_tensor, output_names))
+        return (feeds, fetches)
+
+
+class GraphBuilderSession(object):
+    """
+    GraphBuilderSession, a thin wrapper for TensorFlow's `Session`.
+    It provides a GraphBuilder object which provides
+    - various helper functions for locating and naming graph elements
+    - importing existing GraphFunction object as a subgraph
+    - exporting current graph as an GraphFunction object
+    
+    :param g: Graph, use the provided TensorFlow graph as default graph
+    :param wrap_keras: bool, whether to also let Keras TensorFlow backend use this session
+    """
+    def __init__(self, g=None, wrap_keras=False):
+        self.builder = GraphBuilder(g or tf.Graph())
+        if wrap_keras:
+            self.keras_prev_sess = K.get_session()
+        else:
+            self.keras_prev_sess = None
+    
+    def __enter__(self):
+        self.builder.sess.as_default()
+        self.builder.sess.__enter__()
+        if self.keras_prev_sess is not None:
+            K.set_session(self.builder.sess)
+        return self.builder
+
+    def __exit__(self, *args):
+        if self.keras_prev_sess is not None:
+            K.set_session(self.keras_prev_sess)
+        self.builder.sess.__exit__(*args)
+
+
+
+class GraphFunction(object):
+    """
+    Represent a TensorFlow graph with its GraphDef, input and output operation names.
+    
+    :param graph_def: GraphDef, a static ProtocolBuffer object holding informations of a TensorFlow graph
+    :param input_names: names to the input graph elements (must be of Placeholder type)
+    :param output_names: names to the output graph elements
+    """
+
+    def __init__(self, graph_def, input_names, output_names):
+        """
+        :param graph_def: GraphDef object
+        :param input_names: list of input (operation) names (must be typed `Placeholder`)
+        :param output_names: list of output (operation) names
+        """
+        self.graph_def = graph_def
+        self.input_names = input_names
+        self.output_names = output_names
+
+    @classmethod
+    def from_file(cls, fpath):
+        """
+        Load an existing GraphFunction from file.
+        This implementation uses `joblib` to provide good I/O performance
+        
+        :param fpath: str or path, path to the serialized GraphFunction
+        """
+        _st = jl.load(fpath)
+        assert set(['inputs', 'graph_def_bytes', 'outputs']) <= set(_st.keys())
+        gdef = tf.GraphDef.FromString(_st["graph_def_bytes"])  # pylint: disable=E1101
+        return cls(graph_def=gdef,
+                   input_names=_st["inputs"],
+                   output_names=_st["outputs"])        
+        
+    def dump(self, fpath):
+        """
+        Store the GraphFunction to a file
+
+        :param fpath: str or path, path to the serialized GraphFunction        
+        """
+        _st = {"graph_def_bytes": self.graph_def.SerializeToString(),
+               "inputs": self.input_names,
+               "outputs": self.output_names}
+        assert isinstance(fpath, six.string_types)
+        if not fpath.endswith("jl"):
+            fpath += ".jl"
+        jl.dump(_st, fpath)    

--- a/python/sparkdl/graph_factory.py
+++ b/python/sparkdl/graph_factory.py
@@ -1,0 +1,166 @@
+#
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import logging
+from pathlib import Path
+import shutil
+import six
+from tempfile import mkdtemp
+
+import keras.backend as K
+from keras.models import Model as KerasModel, load_model
+import tensorflow as tf
+
+from .graph_builder import GraphBuilderSession
+from .image.imageIO import SparkMode
+
+logger = logging.getLogger('sparkdl')
+
+class GraphFunctionFactory(object):
+    """ 
+    Build various pieces of the function
+    """
+
+    @classmethod
+    def build_spimage_converter(cls, img_dtype):
+        """ 
+        Convert a imageIO byte encoded image into a image tensor suitable as input to ConvNets
+        The name of the input must be a subset of those specified in `image.imageIO.imgSchema`.
+
+        :param img_dtype: the type of data the underlying image bytes represent
+        """
+        with GraphBuilderSession() as builder:
+            # Flat image data -> image dimensions
+            # This has to conform to `imageIO.imgSchema`
+            height = tf.placeholder(tf.int32, [], name="height")
+            width = tf.placeholder(tf.int32, [], name="width")
+            num_channels = tf.placeholder(tf.int32, [], name="nChannels")
+            image_buffer = tf.placeholder(tf.string, [], name="data")
+
+            # The image is packed into bytes with height as leading dimension
+            # This is the default behavior of Python Image Library
+            shape = tf.reshape(tf.stack([height, width, num_channels], axis=0), 
+                               shape=(3,), name='shape')
+            if "RGB" == img_dtype:
+                image_uint8 = tf.decode_raw(image_buffer, tf.uint8, name="decode_raw")
+                image_float = tf.to_float(image_uint8)
+            else:
+                assert img_dtype == SparkMode.FLOAT32, "Unsupported dtype for image: %s" % img_dtype
+                image_float = tf.decode_raw(image_buffer, tf.float32, name="decode_raw")
+
+            image_reshaped = tf.reshape(image_float, shape, name="reshaped")
+            image_input = tf.expand_dims(image_reshaped, 0, name="image_input")
+            gfn = builder.asGraphFunction([height, width, image_buffer, num_channels], [image_input])
+
+        return gfn
+
+    @classmethod
+    def build_identity(cls):
+        with GraphBuilderSession() as builder:
+            pred_input = tf.placeholder(tf.float32, [None, None])
+            final_output = tf.identity(pred_input, name='output')
+            gfn = builder.asGraphFunction([pred_input], [final_output])
+
+        return gfn
+
+    @classmethod
+    def build_flattener(cls):
+        with GraphBuilderSession() as builder:
+            mat_input = tf.placeholder(tf.float32, [None, None])
+            mat_output = tf.identity(tf.reshape(mat_input, shape=[-1]), name='output')
+            gfn = builder.asGraphFunction([mat_input], [mat_output])
+
+        return gfn
+    
+    @classmethod
+    def import_bare_keras(cls, model_or_file_path):
+        """ Build an UDF from a Keras model
+        """
+        if isinstance(model_or_file_path, KerasModel):
+            model = model_or_file_path
+            model_path = Path(mkdtemp(prefix='kera-')) / "model.h5"
+            # Save to tempdir and restore in a new session
+            model.save(str(model_path), overwrite=True)
+            is_temp_model = True
+        else:
+            model_path = model_or_file_path
+            is_temp_model = False
+
+        # Keras load function requires path string
+        if not isinstance(model_path, six.string_types):
+            model_path = str(model_path)
+
+        with GraphBuilderSession(wrap_keras=True) as builder:
+            K.set_session(builder.sess)
+            K.set_learning_phase(0) # Testing phase
+            model = load_model(model_path)
+            if is_temp_model:
+                shutil.rmtree(str(Path(model_path).parent), ignore_errors=True)
+
+            gfn = builder.asGraphFunction(model.inputs, model.outputs)
+
+        return gfn
+
+    @classmethod
+    def pipeline(cls, functions):
+        """ 
+        Takes multiple graph functions and merges them into a single graph function.
+        It is assumed that there is only one input and one output in the intermediary layers
+
+        :param functions: a list of tuples (scope name, GraphFunction object).
+        """
+        assert len(functions) >= 1, ("must provide at least one function", functions)
+        if 1 == len(functions):
+            return functions[0]
+        for (scope_in, gfn_in), (scope_out, gfn_out) in zip(functions[:-1], functions[1:]):
+            assert len(gfn_in.output_names) == len(gfn_out.input_names), \
+                "graph function link {} -> {} require compatible layers".format(scope_in, scope_out)
+            if len(gfn_out.input_names) != 1:
+                raise NotImplementedError("Only support single input/output for intermediary layers")
+
+        # Acquire initial placeholders' properties
+        with GraphBuilderSession() as builder:
+            _, first_gfn = functions[0]
+            feeds, _ = builder.import_graph_function(first_gfn, name='')
+            first_input_info = []
+            for tnsr in feeds:
+                name = builder.op_name(tnsr)
+                first_input_info.append((tnsr.dtype, tnsr.shape, name))
+
+        # Build a linear chain of all the provide functions
+        with GraphBuilderSession() as builder: 
+            first_inputs = [tf.placeholder(dtype, shape, name)
+                            for (dtype, shape, name) in first_input_info]
+            prev_outputs = first_inputs
+
+            for idx, (scope, gfn) in enumerate(functions):
+                # Give a scope to each function to avoid name conflict
+                if scope is None or len(scope.strip()) == 0:
+                    scope = 'GFN-BLK-{}'.format(idx)
+                logger.info('merge: stage {}, scope {}'.format(idx, scope))
+                input_map = dict(zip(gfn.input_names, prev_outputs))
+                _, fetches = builder.import_graph_function(
+                    gfn, name=scope, input_map=input_map)
+                prev_outputs = fetches
+
+            # Add a non-scoped output name as the output node
+            last_output_names = functions[-1][1].output_names
+            last_outputs = []
+            for tnsr, name in zip(prev_outputs, last_output_names):
+                last_outputs.append(tf.identity(tnsr, name=name))
+
+            gfn = builder.asGraphFunction(first_inputs, last_outputs)
+
+        return gfn

--- a/python/tests/graph_builder_test.py
+++ b/python/tests/graph_builder_test.py
@@ -1,0 +1,138 @@
+#
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+
+from glob import glob
+import os
+
+import numpy as np
+import tensorflow as tf
+import keras.backend as K
+from keras.applications import InceptionV3
+from keras.applications import inception_v3 as iv3
+
+from pyspark import SparkContext
+from pyspark.sql import DataFrame, Row
+from pyspark.sql.functions import udf
+
+from sparkdl.graph_builder import GraphBuilderSession
+from .tests import SparkDLTestCase
+from .transformers.image_utils import _getSampleJPEGDir, getSampleImagePathsDF
+
+def get_image_paths_df(sqlCtx):
+    df = getSampleImagePathsDF(sqlCtx, "fpath")
+    df.createOrReplaceTempView("_test_image_paths_df")
+    return df
+
+
+class GraphBuilderTest(SparkDLTestCase):
+
+    def test_tf_consistency(self):
+        """ Should get the same graph as running pure tf """
+
+        x_val = 2702.142857
+        g = tf.Graph()
+        with tf.Session(graph=g) as sess:
+            x = tf.placeholder(tf.double, shape=[], name="x")
+            z = tf.add(x, 3, name='z')
+            gdef_ref = g.as_graph_def(add_shapes=True)
+            z_ref = sess.run(z, {x: x_val})
+
+        with GraphBuilderSession() as builder:
+            x = tf.placeholder(tf.double, shape=[], name="x")
+            z = tf.add(x, 3, name='z')
+            z_tgt = builder.sess.run(z, {x: x_val})
+            gfn = builder.asGraphFunction([x], [z])
+
+        assert z_ref == z_tgt
+
+        # Version texts are not essential part of the graph, ignore them
+        gdef_ref.ClearField("versions")
+        gfn.graph_def.ClearField("versions")
+
+        # The GraphDef contained in the GraphFunction object
+        # should be the same as that in the one exported directly from TensorFlow session
+        assert str(gfn.graph_def) == str(gdef_ref)
+
+
+    def test_get_graph_elemets(self):
+        """ Fetching graph elemetns by names and other graph element objects """
+
+        with GraphBuilderSession() as builder:
+            x = tf.placeholder(tf.double, shape=[], name="x")
+            z = tf.add(x, 3, name='z')
+
+            g = builder.graph
+            self.assertEqual(builder.get_tensor(z), z)
+            self.assertEqual(builder.get_tensor(x), x)
+            self.assertEqual(g.get_tensor_by_name("x:0"), builder.get_tensor(x))
+            self.assertEqual("x:0", builder.tensor_name(x))
+            self.assertEqual(g.get_operation_by_name("x"), builder.get_op(x))
+            self.assertEqual("x", builder.op_name(x))
+            self.assertEqual("x", builder.op_name(x))
+            self.assertEqual("z", builder.op_name(z))
+            self.assertEqual(builder.get_tensor(z), z)
+            self.assertEqual(builder.get_tensor(x), x)
+
+
+    def test_import_export_graph_function(self):
+        """ Function import and export must be consistent """
+
+        with GraphBuilderSession() as builder:
+            x = tf.placeholder(tf.double, shape=[], name="x")
+            z = tf.add(x, 3, name='z')
+            gfn_ref = builder.asGraphFunction([x], [z])
+
+        with GraphBuilderSession() as builder:
+            feeds, fetches = builder.import_graph_function(gfn_ref, name="")
+            gfn_tgt = builder.asGraphFunction(feeds, fetches)
+
+        self.assertEqual(gfn_tgt.input_names, gfn_ref.input_names)
+        self.assertEqual(gfn_tgt.output_names, gfn_ref.output_names)
+        self.assertEqual(str(gfn_tgt.graph_def), str(gfn_ref.graph_def))
+
+
+    def test_keras_consistency(self):
+        """ Exported model in Keras should get same result as original """
+
+        img_fpaths = glob(os.path.join(_getSampleJPEGDir(), '*.jpg'))
+
+        def keras_load_img(fpath):
+            from keras.preprocessing.image import load_img, img_to_array
+            import numpy as np
+            img = load_img(fpath, target_size=(299, 299))
+            img_arr = img_to_array(img)
+            img_iv3_input = iv3.preprocess_input(img_arr)
+            return np.expand_dims(img_iv3_input, axis=0)
+
+        imgs_iv3_input = np.vstack([keras_load_img(fp) for fp in img_fpaths])
+
+        model_ref = InceptionV3(weights="imagenet")
+        preds_ref = model_ref.predict(imgs_iv3_input)
+
+        with GraphBuilderSession(wrap_keras=True) as builder:
+            K.set_learning_phase(0)
+            model = InceptionV3(weights="imagenet")
+            gfn = builder.asGraphFunction(model.inputs, model.outputs)
+
+        with GraphBuilderSession(wrap_keras=True) as builder:
+            K.set_learning_phase(0)
+            feeds, fetches = builder.import_graph_function(gfn, name="InceptionV3")
+            preds_tgt = builder.sess.run(fetches[0], {feeds[0]: imgs_iv3_input})
+
+        self.assertTrue(np.all(preds_tgt == preds_ref))
+


### PR DESCRIPTION
## What changes are proposed in this pull request?

We built a thin wrapper on top of TensorFlow's Session
to help us creating functions (and specifically, UDFs)
and composing subgraph (either Keras or TensorFlow).

This is functionality would be for **INTERNAL DEVELOPER ONLY**.

## How is this patch tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests
