### PR TITLE
Testing on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
-jdk:
-  - oraclejdk8 # openJDK crashes sometimes; tensorframes is compiled w.r.t JDK8
-
 sudo: required
 
 dist: trusty
+
+language: python
+python:
+  - "2.7"
+  - "3.6"
+  - "3.5"
 
 cache:
   directories:
@@ -18,9 +21,13 @@ env:
 before_install:
  - ./bin/download_travis_dependencies.sh
 
+install:
+ - pip install -r ./python/requirements.txt
+
 script:
   - ./build/sbt -Dspark.version=$SPARK_VERSION -Dscala.version=$SCALA_VERSION "set test in assembly := {}" assembly
   - ./build/sbt -Dspark.version=$SPARK_VERSION -Dscala.version=$SCALA_VERSION coverage test coverageReport
+  - SPARK_HOME=$HOME/.cache/spark-versions/$SPARK_BUILD ./python/run-tests.sh
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,8 +1,9 @@
 # This file should list any python package dependencies.
+coverage==4.4.1
 h5py==2.7.0
 keras==2.0.4
 nose==1.3.7  # for testing
 numpy==1.11.2
 pillow==4.1.1
-tensorflow==1.1.0
 pygments==2.2.0
+tensorflow==1.1.0

--- a/python/run-tests.sh
+++ b/python/run-tests.sh
@@ -97,7 +97,7 @@ for noseOptions in $noseOptionsArr
 do
   echo "============= Running the tests in: $noseOptions ============="
   # The grep below is a horrible hack for spark 1.x: we manually remove some log lines to stay below the 4MB log limit on Travis.
-  $PYSPARK_DRIVER_PYTHON -m "nose" -v --exe "$noseOptions" 2>&1 | grep -vE "INFO (ParquetOutputFormat|SparkContext|ContextCleaner|ShuffleBlockFetcherIterator|MapOutputTrackerMaster|TaskSetManager|Executor|MemoryStore|CacheManager|BlockManager|DAGScheduler|PythonRDD|TaskSchedulerImpl|ZippedPartitionsRDD2)";
+  $PYSPARK_DRIVER_PYTHON -m "nose" --with-coverage -v --exe "$noseOptions" 2>&1 | grep -vE "INFO (ParquetOutputFormat|SparkContext|ContextCleaner|ShuffleBlockFetcherIterator|MapOutputTrackerMaster|TaskSetManager|Executor|MemoryStore|CacheManager|BlockManager|DAGScheduler|PythonRDD|TaskSchedulerImpl|ZippedPartitionsRDD2)";
 
   # Exit immediately if the tests fail.
   # Since we pipe to remove the output, we need to use some horrible BASH features:

--- a/python/sparkdl/utils.py
+++ b/python/sparkdl/utils.py
@@ -67,7 +67,7 @@ class JVMAPI(object):
         return cls._curr_jvm().PythonUtils
 
 def list_to_vector_udf(col):
-    return Column(JVMAPI.default().listToVectorFunction(col._jc))  # pylint: disable=W0212
+    return Column(JVMAPI.default().listToMLlibVectorUDF(col._jc))  # pylint: disable=W0212
 
 def pipelined_udf(name, ordered_udf_names):
     """ Given a sequence of @ordered_udf_names f1, f2, ..., fn

--- a/python/tests/transformers/image_utils.py
+++ b/python/tests/transformers/image_utils.py
@@ -70,7 +70,7 @@ class ImageNetOutputComparisonTestCase(unittest.TestCase):
         """
         values1 & values2 are {key => numpy array}.
         """
-        for k, v1 in values1.iteritems():
+        for k, v1 in values1.items():
             v1f = v1.astype(np.float32)
             v2f = values2[k].astype(np.float32)
             np.testing.assert_array_equal(v1f, v2f)
@@ -79,14 +79,14 @@ class ImageNetOutputComparisonTestCase(unittest.TestCase):
         """
         preds1 & preds2 are {key => (class, description, probability)}.
         """
-        for k, v1 in preds1.iteritems():
+        for k, v1 in preds1.items():
             self.assertEqual([v[1] for v in v1], [v[1] for v in preds2[k]])
 
     def compareClassSets(self, preds1, preds2):
         """
         values1 & values2 are {key => numpy array}.
         """
-        for k, v1 in preds1.iteritems():
+        for k, v1 in preds1.items():
             self.assertEqual(set([v[1] for v in v1]), set([v[1] for v in preds2[k]]))
 
 

--- a/python/tests/transformers/keras_image_test.py
+++ b/python/tests/transformers/keras_image_test.py
@@ -18,7 +18,7 @@ from sparkdl.transformers.keras_image import KerasImageFileTransformer
 from sparkdl.transformers.utils import InceptionV3Constants
 from ..tests import SparkDLTestCase
 from .image_utils import ImageNetOutputComparisonTestCase
-import image_utils
+from . import image_utils
 
 
 class KerasImageFileTransformerTest(SparkDLTestCase):

--- a/python/tests/transformers/tf_image_test.py
+++ b/python/tests/transformers/tf_image_test.py
@@ -27,7 +27,7 @@ import sparkdl.transformers.utils as utils
 from sparkdl.transformers.utils import ImageNetConstants, InceptionV3Constants
 from ..tests import SparkDLTestCase
 from .image_utils import ImageNetOutputComparisonTestCase
-import image_utils
+from . import image_utils
 
 
 class TFImageTransformerExamplesTest(SparkDLTestCase, ImageNetOutputComparisonTestCase):


### PR DESCRIPTION
This PR adds a travis config file and does a little refactoring to stay within travis's memory limit and pass tests using python3.