### PR TITLE
Adding generic support for Keras pre-trained models

### DIFF
--- a/python/sparkdl/transformers/keras_applications.py
+++ b/python/sparkdl/transformers/keras_applications.py
@@ -20,8 +20,7 @@ from keras.applications import inception_v3, resnet50, vgg16, vgg19, xception
 from keras.applications.imagenet_utils import decode_predictions
 import tensorflow as tf
 
-from sparkdl.transformers.utils import (
-    imageInputPlaceholder, InceptionV3Constants)
+from sparkdl.transformers.utils import (imageInputPlaceholder, InceptionV3Constants)
 
 
 KERAS_APPLICATION_MODELS = set(["InceptionV3"]) #, "ResNet50", "Xception", "VGG16", "VGG19"])
@@ -86,6 +85,13 @@ class KerasApplicationModel:
         """
         pass
 
+    @abstractmethod
+    def testKerasModel(self):
+        """
+        For testing, the keras model object to compare to.
+        """
+        pass
+
 
 class InceptionV3Model(KerasApplicationModel):
     def preprocess(self, inputImage):
@@ -101,4 +107,5 @@ class InceptionV3Model(KerasApplicationModel):
     def numOutputFeatures(self):
         return InceptionV3Constants.NUM_OUTPUT_FEATURES
 
-
+    def testKerasModel(self):
+        return inception_v3.InceptionV3()

--- a/python/sparkdl/transformers/keras_applications.py
+++ b/python/sparkdl/transformers/keras_applications.py
@@ -16,18 +16,18 @@
 from abc import ABCMeta, abstractmethod
 
 import keras.backend as K
-from keras.applications import inception_v3, resnet50, vgg16, vgg19, xception
+from keras.applications import inception_v3
 from keras.applications.imagenet_utils import decode_predictions
 import tensorflow as tf
 
 from sparkdl.transformers.utils import (imageInputPlaceholder, InceptionV3Constants)
 
 
-KERAS_APPLICATION_MODELS = set(["InceptionV3"]) #, "ResNet50", "Xception", "VGG16", "VGG19"])
+KERAS_APPLICATION_MODELS = set(["InceptionV3"])
 
 
 """
-Essentially a factory function for getting the correct KerasApplicationModelSession class
+Essentially a factory function for getting the correct KerasApplicationModel class
 for the network name.
 """
 def getKerasApplicationModel(name):
@@ -37,14 +37,6 @@ def getKerasApplicationModel(name):
 
     if name == "InceptionV3":
         return InceptionV3Model()
-    # elif name == "ResNet50":
-    #     return ResNet50Model()
-    # elif name == "Xception":
-    #     return XceptionModel()
-    # elif name == "VGG16":
-    #     return VGG16Model()
-    # elif name == "VGG19":
-    #     return VGG19Model()
     else:
         raise ValueError("%s is not implemented but is in the supported models list: %s" %
                          name, str(KERAS_APPLICATION_MODELS))
@@ -108,4 +100,4 @@ class InceptionV3Model(KerasApplicationModel):
         return InceptionV3Constants.NUM_OUTPUT_FEATURES
 
     def testKerasModel(self):
-        return inception_v3.InceptionV3()
+        return inception_v3.InceptionV3(weights="imagenet")

--- a/python/sparkdl/transformers/keras_applications.py
+++ b/python/sparkdl/transformers/keras_applications.py
@@ -21,8 +21,7 @@ from keras.applications.imagenet_utils import decode_predictions
 import tensorflow as tf
 
 from sparkdl.transformers.utils import (
-    imageInputPlaceholder, InceptionV3Constants) #, ResNet50Constants)
-
+    imageInputPlaceholder, InceptionV3Constants)
 
 
 KERAS_APPLICATION_MODELS = set(["InceptionV3"]) #, "ResNet50", "Xception", "VGG16", "VGG19"])

--- a/python/sparkdl/transformers/keras_applications.py
+++ b/python/sparkdl/transformers/keras_applications.py
@@ -1,0 +1,105 @@
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from abc import ABCMeta, abstractmethod
+
+import keras.backend as K
+from keras.applications import inception_v3, resnet50, vgg16, vgg19, xception
+from keras.applications.imagenet_utils import decode_predictions
+import tensorflow as tf
+
+from sparkdl.transformers.utils import (
+    imageInputPlaceholder, InceptionV3Constants) #, ResNet50Constants)
+
+
+
+KERAS_APPLICATION_MODELS = set(["InceptionV3"]) #, "ResNet50", "Xception", "VGG16", "VGG19"])
+
+
+"""
+Essentially a factory function for getting the correct KerasApplicationModelSession class
+for the network name.
+"""
+def getKerasApplicationModel(name):
+    if name not in KERAS_APPLICATION_MODELS:
+        raise ValueError("%s is not a supported model. Supported models: %s" % name,
+                         str(KERAS_APPLICATION_MODELS))
+
+    if name == "InceptionV3":
+        return InceptionV3Model()
+    # elif name == "ResNet50":
+    #     return ResNet50Model()
+    # elif name == "Xception":
+    #     return XceptionModel()
+    # elif name == "VGG16":
+    #     return VGG16Model()
+    # elif name == "VGG19":
+    #     return VGG19Model()
+    else:
+        raise ValueError("%s is not implemented but is in the supported models list: %s" %
+                         name, str(KERAS_APPLICATION_MODELS))
+
+
+class KerasApplicationModel:
+    __metaclass__ = ABCMeta
+
+    def getModelData(self, featurize):
+        sess = tf.Session()
+        with sess.as_default():
+            K.set_learning_phase(0)
+            inputImage = imageInputPlaceholder(nChannels=3)
+            preprocessed = self.preprocess(inputImage)
+            model = self.model(preprocessed, featurize)
+        return dict(inputTensorName=inputImage.name,
+                    outputTensorName=model.output.name,
+                    session=sess,
+                    inputTensorSize=self.inputShape(),
+                    outputMode="vector")
+
+    @abstractmethod
+    def preprocess(self, inputImage):
+        pass
+
+    @abstractmethod
+    def model(self, preprocessed, featurize):
+        pass
+
+    @abstractmethod
+    def inputShape(self):
+        pass
+
+    @abstractmethod
+    def numOutputFeatures(self):
+        """
+        For testing
+        """
+        pass
+
+
+class InceptionV3Model(KerasApplicationModel):
+    def preprocess(self, inputImage):
+        return inception_v3.preprocess_input(inputImage)
+
+    def model(self, preprocessed, featurize):
+        return inception_v3.InceptionV3(input_tensor=preprocessed, weights="imagenet",
+                                        include_top=(not featurize))
+
+    def inputShape(self):
+        return InceptionV3Constants.INPUT_SHAPE
+
+    def numOutputFeatures(self):
+        return InceptionV3Constants.NUM_OUTPUT_FEATURES
+
+

--- a/python/sparkdl/transformers/named_image.py
+++ b/python/sparkdl/transformers/named_image.py
@@ -30,8 +30,6 @@ import sparkdl.transformers.keras_applications as keras_apps
 from sparkdl.transformers.param import (
     keyword_only, HasInputCol, HasOutputCol, SparkDLTypeConverters)
 from sparkdl.transformers.tf_image import TFImageTransformer
-# from sparkdl.transformers.utils import (
-#     imageInputPlaceholder, InceptionV3Constants, ResNet50Constants)
 
 
 SUPPORTED_MODELS = ["InceptionV3"]
@@ -225,61 +223,15 @@ class _NamedImageTransformer(Transformer, HasInputCol, HasOutputCol):
         return result.drop(resizedCol)
 
 
-# def _buildTFGraphForName(name, featurize):
-#     if name == "InceptionV3":
-#         modelData = _buildInceptionV3Session(featurize)
-#     # elif name == "ResNet50":
-#     #     modelData = _buildResNet50Session(featurize)
-#     else:
-#         raise ValueError("%s is not a supported model. Supported models: %s" % name,
-#                          str(SUPPORTED_MODELS))
-
-#     sess = modelData["session"]
-#     outputTensorName = modelData["outputTensorName"]
-#     graph = tfx.strip_and_freeze_until([outputTensorName], sess.graph, sess, return_graph=True)
-
-#     modelData["graph"] = graph
-#     return modelData
-
 def _buildTFGraphForName(name, featurize):
     if name not in keras_apps.KERAS_APPLICATION_MODELS:
         raise ValueError("%s is not a supported model. Supported models: %s" % name,
                          str(KERAS_APPLICATION_MODELS))
 
     modelData = keras_apps.getKerasApplicationModel(name).getModelData(featurize)
-
     sess = modelData["session"]
     outputTensorName = modelData["outputTensorName"]
     graph = tfx.strip_and_freeze_until([outputTensorName], sess.graph, sess, return_graph=True)
-
     modelData["graph"] = graph
+
     return modelData
-
-
-# def _buildInceptionV3Session(featurize):
-#     sess = tf.Session()
-#     with sess.as_default():
-#         K.set_learning_phase(0)
-#         inputImage = imageInputPlaceholder(nChannels=3)
-#         preprocessed = inception_v3.preprocess_input(inputImage)
-#         model = InceptionV3(input_tensor=preprocessed, weights="imagenet",
-#                             include_top=(not featurize))
-#     return dict(inputTensorName=inputImage.name,
-#                 outputTensorName=model.output.name,
-#                 session=sess,
-#                 inputTensorSize=InceptionV3Constants.INPUT_SHAPE,
-#                 outputMode="vector")
-
-# def _buildResNet50Session(featurize):
-#     sess = tf.Session()
-#     with sess.as_default():
-#         K.set_learning_phase(0)
-#         inputImage = imageInputPlaceholder(nChannels=3)
-#         preprocessed = resnet50.preprocess_input(inputImage)
-#         model = ResNet50(input_tensor=preprocessed, weights="imagenet",
-#                             include_top=(not featurize))
-#     return dict(inputTensorName=inputImage.name,
-#                 outputTensorName=model.output.name,
-#                 session=sess,
-#                 inputTensorSize=ResNet50Constants.INPUT_SHAPE,
-#                 outputMode="vector")

--- a/python/sparkdl/transformers/named_image.py
+++ b/python/sparkdl/transformers/named_image.py
@@ -14,7 +14,7 @@
 #
 
 import keras.backend as K
-from keras.applications import InceptionV3, inception_v3
+from keras.applications import InceptionV3, inception_v3, ResNet50, resnet50
 from keras.applications.imagenet_utils import decode_predictions
 import numpy as np
 import tensorflow as tf
@@ -26,14 +26,15 @@ from pyspark.sql.types import (ArrayType, FloatType, StringType, StructField, St
 
 import sparkdl.graph.utils as tfx
 from sparkdl.image.imageIO import resizeImage
+import sparkdl.transformers.keras_applications as keras_apps
 from sparkdl.transformers.param import (
     keyword_only, HasInputCol, HasOutputCol, SparkDLTypeConverters)
 from sparkdl.transformers.tf_image import TFImageTransformer
 from sparkdl.transformers.utils import (
-    imageInputPlaceholder, InceptionV3Constants)
+    imageInputPlaceholder, InceptionV3Constants, ResNet50Constants)
 
 
-SUPPORTED_MODELS = ["InceptionV3"]
+SUPPORTED_MODELS = ["InceptionV3", "ResNet50"]
 
 
 class DeepImagePredictor(Transformer, HasInputCol, HasOutputCol):
@@ -224,12 +225,28 @@ class _NamedImageTransformer(Transformer, HasInputCol, HasOutputCol):
         return result.drop(resizedCol)
 
 
+# def _buildTFGraphForName(name, featurize):
+#     if name == "InceptionV3":
+#         modelData = _buildInceptionV3Session(featurize)
+#     # elif name == "ResNet50":
+#     #     modelData = _buildResNet50Session(featurize)
+#     else:
+#         raise ValueError("%s is not a supported model. Supported models: %s" % name,
+#                          str(SUPPORTED_MODELS))
+
+#     sess = modelData["session"]
+#     outputTensorName = modelData["outputTensorName"]
+#     graph = tfx.strip_and_freeze_until([outputTensorName], sess.graph, sess, return_graph=True)
+
+#     modelData["graph"] = graph
+#     return modelData
+
 def _buildTFGraphForName(name, featurize):
-    if name == "InceptionV3":
-        modelData = _buildInceptionV3Session(featurize)
-    else:
+    if name not in keras_apps.KERAS_APPLICATION_MODELS:
         raise ValueError("%s is not a supported model. Supported models: %s" % name,
-                         str(SUPPORTED_MODELS))
+                         str(KERAS_APPLICATION_MODELS))
+
+    modelData = keras_apps.getKerasApplicationModel(name).getModelData(featurize)
 
     sess = modelData["session"]
     outputTensorName = modelData["outputTensorName"]
@@ -239,16 +256,30 @@ def _buildTFGraphForName(name, featurize):
     return modelData
 
 
-def _buildInceptionV3Session(featurize):
-    sess = tf.Session()
-    with sess.as_default():
-        K.set_learning_phase(0)
-        inputImage = imageInputPlaceholder(nChannels=3)
-        preprocessed = inception_v3.preprocess_input(inputImage)
-        model = InceptionV3(input_tensor=preprocessed, weights="imagenet",
-                            include_top=(not featurize))
-    return dict(inputTensorName=inputImage.name,
-                outputTensorName=model.output.name,
-                session=sess,
-                inputTensorSize=InceptionV3Constants.INPUT_SHAPE,
-                outputMode="vector")
+# def _buildInceptionV3Session(featurize):
+#     sess = tf.Session()
+#     with sess.as_default():
+#         K.set_learning_phase(0)
+#         inputImage = imageInputPlaceholder(nChannels=3)
+#         preprocessed = inception_v3.preprocess_input(inputImage)
+#         model = InceptionV3(input_tensor=preprocessed, weights="imagenet",
+#                             include_top=(not featurize))
+#     return dict(inputTensorName=inputImage.name,
+#                 outputTensorName=model.output.name,
+#                 session=sess,
+#                 inputTensorSize=InceptionV3Constants.INPUT_SHAPE,
+#                 outputMode="vector")
+
+# def _buildResNet50Session(featurize):
+#     sess = tf.Session()
+#     with sess.as_default():
+#         K.set_learning_phase(0)
+#         inputImage = imageInputPlaceholder(nChannels=3)
+#         preprocessed = resnet50.preprocess_input(inputImage)
+#         model = ResNet50(input_tensor=preprocessed, weights="imagenet",
+#                             include_top=(not featurize))
+#     return dict(inputTensorName=inputImage.name,
+#                 outputTensorName=model.output.name,
+#                 session=sess,
+#                 inputTensorSize=ResNet50Constants.INPUT_SHAPE,
+#                 outputMode="vector")

--- a/python/sparkdl/transformers/named_image.py
+++ b/python/sparkdl/transformers/named_image.py
@@ -30,11 +30,11 @@ import sparkdl.transformers.keras_applications as keras_apps
 from sparkdl.transformers.param import (
     keyword_only, HasInputCol, HasOutputCol, SparkDLTypeConverters)
 from sparkdl.transformers.tf_image import TFImageTransformer
-from sparkdl.transformers.utils import (
-    imageInputPlaceholder, InceptionV3Constants, ResNet50Constants)
+# from sparkdl.transformers.utils import (
+#     imageInputPlaceholder, InceptionV3Constants, ResNet50Constants)
 
 
-SUPPORTED_MODELS = ["InceptionV3", "ResNet50"]
+SUPPORTED_MODELS = ["InceptionV3"]
 
 
 class DeepImagePredictor(Transformer, HasInputCol, HasOutputCol):

--- a/python/sparkdl/transformers/named_image.py
+++ b/python/sparkdl/transformers/named_image.py
@@ -13,11 +13,8 @@
 # limitations under the License.
 #
 
-import keras.backend as K
-from keras.applications import InceptionV3, inception_v3, ResNet50, resnet50
 from keras.applications.imagenet_utils import decode_predictions
 import numpy as np
-import tensorflow as tf
 
 from pyspark.ml import Transformer
 from pyspark.ml.param import Param, Params, TypeConverters

--- a/python/sparkdl/transformers/utils.py
+++ b/python/sparkdl/transformers/utils.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 from pyspark.ml.param import TypeConverters
 
 from sparkdl.image.imageIO import imageType
+from sparkdl.transformers.keras_applications import InceptionV3Model
 
 # image stuff
 
@@ -30,11 +31,8 @@ def imageInputPlaceholder(nChannels=None):
 class ImageNetConstants:
     NUM_CLASSES = 1000
 
-# probably use a separate module for each network once we have featurizers.
-class InceptionV3Constants:
-    INPUT_SHAPE = (299, 299)
-    NUM_OUTPUT_FEATURES = 131072
 
-# class ResNet50Constants:
-#     INPUT_SHAPE = (224, 224)
-#     NUM_OUTPUT_FEATURES = 131072
+# InceptionV3 is used in a lot of tests, so we'll make this shortcut available
+class InceptionV3Constants:
+    INPUT_SHAPE = InceptionV3Model().inputShape()
+    NUM_OUTPUT_FEATURES = InceptionV3Model().numOutputFeatures()

--- a/python/sparkdl/transformers/utils.py
+++ b/python/sparkdl/transformers/utils.py
@@ -34,3 +34,7 @@ class ImageNetConstants:
 class InceptionV3Constants:
     INPUT_SHAPE = (299, 299)
     NUM_OUTPUT_FEATURES = 131072
+
+# class ResNet50Constants:
+#     INPUT_SHAPE = (224, 224)
+#     NUM_OUTPUT_FEATURES = 131072

--- a/python/sparkdl/transformers/utils.py
+++ b/python/sparkdl/transformers/utils.py
@@ -18,7 +18,7 @@ import tensorflow as tf
 from pyspark.ml.param import TypeConverters
 
 from sparkdl.image.imageIO import imageType
-from sparkdl.transformers.keras_applications import InceptionV3Model
+
 
 # image stuff
 
@@ -31,8 +31,8 @@ def imageInputPlaceholder(nChannels=None):
 class ImageNetConstants:
     NUM_CLASSES = 1000
 
-
 # InceptionV3 is used in a lot of tests, so we'll make this shortcut available
+# For other networks, see the keras_applications module.
 class InceptionV3Constants:
-    INPUT_SHAPE = InceptionV3Model().inputShape()
-    NUM_OUTPUT_FEATURES = InceptionV3Model().numOutputFeatures()
+    INPUT_SHAPE = (299, 299)
+    NUM_OUTPUT_FEATURES = 131072

--- a/python/tests/transformers/named_image_test.py
+++ b/python/tests/transformers/named_image_test.py
@@ -23,10 +23,9 @@ from pyspark.sql.functions import udf
 from pyspark.sql.types import IntegerType, StructType, StructField
 
 from sparkdl.image import imageIO
-import sparkdl.transformers.keras_applications as keras_apps
 from sparkdl.transformers.named_image import (DeepImagePredictor, DeepImageFeaturizer,
                                               _buildTFGraphForName)
-#from sparkdl.transformers.utils import InceptionV3Constants
+from sparkdl.transformers.utils import InceptionV3Constants
 from ..tests import SparkDLTestCase
 from .image_utils import getSampleImageDF, getSampleImageList
 
@@ -140,7 +139,7 @@ class NamedImageTransformerImagenetTest(SparkDLTestCase):
         collected = transformed_df.collect()
         for row in collected:
             predictions = row[output_col]
-            self.assertEqual(len(predictions), keras_apps.InceptionV3Model().numOutputFeatures())
+            self.assertEqual(len(predictions), InceptionV3Constants.NUM_OUTPUT_FEATURES)
             # TODO: actually check the value of the output to see if they are reasonable
             # e.g. -- compare to just running with keras.
 

--- a/python/tests/transformers/named_image_test.py
+++ b/python/tests/transformers/named_image_test.py
@@ -57,8 +57,7 @@ class NamedImageTransformerBaseTestCase(SparkDLTestCase):
 
     def test_buildtfgraphforname(self):
         """"
-        Run the graph produced by _buildtfgraphforname and compare the result to above keras
-        result.
+        Run the graph produced by _buildtfgraphforname using tensorflow and compare to keras result.
         """
         imageArray = self.imageArray
         kerasPredict = self.kerasPredict
@@ -169,4 +168,3 @@ class NamedImageTransformerInceptionV3Test(NamedImageTransformerBaseTestCase):
 
     __test__ = True
     name = "InceptionV3"
-

--- a/python/tests/transformers/named_image_test.py
+++ b/python/tests/transformers/named_image_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-from keras.applications import inception_v3
 import numpy as np
 import tensorflow as tf
 
@@ -23,33 +22,38 @@ from pyspark.sql.functions import udf
 from pyspark.sql.types import IntegerType, StructType, StructField
 
 from sparkdl.image import imageIO
+import sparkdl.transformers.keras_applications as keras_apps
 from sparkdl.transformers.named_image import (DeepImagePredictor, DeepImageFeaturizer,
                                               _buildTFGraphForName)
-from sparkdl.transformers.utils import InceptionV3Constants
 from ..tests import SparkDLTestCase
 from .image_utils import getSampleImageDF, getSampleImageList
 
 
-class NamedImageTransformerImagenetTest(SparkDLTestCase):
+class NamedImageTransformerBaseTestCase(SparkDLTestCase):
+
+    __test__ = False
+    name = None
 
     @classmethod
     def setUpClass(cls):
-        super(NamedImageTransformerImagenetTest, cls).setUpClass()
+        super(NamedImageTransformerBaseTestCase, cls).setUpClass()
 
-        # Compute values used by multiple tests.
         imgFiles, images = getSampleImageList()
         imageArray = np.empty((len(images), 299, 299, 3), 'uint8')
         for i, img in enumerate(images):
             assert img is not None and img.mode == "RGB"
             imageArray[i] = np.array(img.resize((299, 299)))
-
-        # Predict the class probabilities for the images in our test library using keras API.
-        prepedImaged = inception_v3.preprocess_input(imageArray.astype('float32'))
-        model = inception_v3.InceptionV3()
-        kerasPredict = model.predict(prepedImaged)
-        # These values are used by multiple tests so cache them on class setup.
         cls.imageArray = imageArray
+
+        # Predict the class probabilities for the images in our test library using keras API
+        # and cache for use by multiple tests.
+        cls.appModel = keras_apps.getKerasApplicationModel(cls.name)
+        preppedImage = cls.appModel.preprocess(imageArray.astype('float32'))
+        kerasPredict = cls.appModel.testKerasModel().predict(preppedImage)
         cls.kerasPredict = kerasPredict
+
+        cls.imageDF = getSampleImageDF().limit(5)
+
 
     def test_buildtfgraphforname(self):
         """"
@@ -58,7 +62,7 @@ class NamedImageTransformerImagenetTest(SparkDLTestCase):
         """
         imageArray = self.imageArray
         kerasPredict = self.kerasPredict
-        modelGraphInfo = _buildTFGraphForName("InceptionV3", False)
+        modelGraphInfo = _buildTFGraphForName(self.name, False)
         graph = modelGraphInfo["graph"]
         sess = tf.Session(graph=graph)
         with sess.as_default():
@@ -71,8 +75,8 @@ class NamedImageTransformerImagenetTest(SparkDLTestCase):
 
     def test_DeepImagePredictorNoReshape(self):
         """
-        Run sparkDL inceptionV3 transformer on resized images and compare result to cached keras
-        result.
+        Run sparkDL transformer on manually-resized images and compare result to the
+        keras result.
         """
         imageArray = self.imageArray
         kerasPredict = self.kerasPredict
@@ -87,8 +91,8 @@ class NamedImageTransformerImagenetTest(SparkDLTestCase):
         dfType = StructType([StructField("image", imageIO.imageSchema)])
         imageDf = rdd.toDF(dfType)
 
-        transformer = DeepImagePredictor(inputCol='image', modelName="InceptionV3",
-                                         outputCol="prediction",)
+        transformer = DeepImagePredictor(inputCol='image', modelName=self.name,
+                                         outputCol="prediction")
         dfPredict = transformer.transform(imageDf).collect()
         dfPredict = np.array([i.prediction for i in dfPredict])
 
@@ -97,14 +101,13 @@ class NamedImageTransformerImagenetTest(SparkDLTestCase):
 
     def test_DeepImagePredictor(self):
         """
-        Run sparkDL inceptionV3 transformer on raw (original size) images and compare result to
+        Run sparkDL transformer on raw (original size) images and compare result to
         above keras (using keras resizing) result.
         """
         kerasPredict = self.kerasPredict
-        transformer = DeepImagePredictor(inputCol='image', modelName="InceptionV3",
+        transformer = DeepImagePredictor(inputCol='image', modelName=self.name,
                                          outputCol="prediction",)
-        origImgDf = getSampleImageDF()
-        fullPredict = transformer.transform(origImgDf).collect()
+        fullPredict = transformer.transform(self.imageDF).collect()
         fullPredict = np.array([i.prediction for i in fullPredict])
 
         self.assertEqual(kerasPredict.shape, fullPredict.shape)
@@ -112,14 +115,12 @@ class NamedImageTransformerImagenetTest(SparkDLTestCase):
         # TODO: match keras resize step to get closer prediction
         np.testing.assert_array_almost_equal(kerasPredict, fullPredict, decimal=6)
 
-    def test_inceptionV3_prediction_decoded(self):
+    def test_prediction_decoded(self):
         output_col = "prediction"
         topK = 10
         transformer = DeepImagePredictor(inputCol="image", outputCol=output_col,
-                                         modelName="InceptionV3", decodePredictions=True, topK=topK)
-
-        image_df = getSampleImageDF()
-        transformed_df = transformer.transform(image_df.limit(5))
+                                         modelName=self.name, decodePredictions=True, topK=topK)
+        transformed_df = transformer.transform(self.imageDF)
 
         collected = transformed_df.collect()
         for row in collected:
@@ -128,18 +129,16 @@ class NamedImageTransformerImagenetTest(SparkDLTestCase):
             # TODO: actually check the value of the output to see if they are reasonable
             # e.g. -- compare to just running with keras.
 
-    def test_inceptionV3_featurization(self):
+    def test_featurization(self):
         output_col = "prediction"
         transformer = DeepImageFeaturizer(inputCol="image", outputCol=output_col,
-                                          modelName="InceptionV3")
-
-        image_df = getSampleImageDF()
-        transformed_df = transformer.transform(image_df.limit(5))
+                                          modelName=self.name)
+        transformed_df = transformer.transform(self.imageDF)
 
         collected = transformed_df.collect()
         for row in collected:
             predictions = row[output_col]
-            self.assertEqual(len(predictions), InceptionV3Constants.NUM_OUTPUT_FEATURES)
+            self.assertEqual(len(predictions), self.appModel.numOutputFeatures())
             # TODO: actually check the value of the output to see if they are reasonable
             # e.g. -- compare to just running with keras.
 
@@ -149,19 +148,25 @@ class NamedImageTransformerImagenetTest(SparkDLTestCase):
         Does not test how good the featurization is for generalization.
         """
         featurizer = DeepImageFeaturizer(inputCol="image", outputCol="features",
-                                         modelName="InceptionV3")
+                                         modelName=self.name)
         lr = LogisticRegression(maxIter=20, regParam=0.05, elasticNetParam=0.3, labelCol="label")
         pipeline = Pipeline(stages=[featurizer, lr])
 
         # add arbitrary labels to run logistic regression
         # TODO: it's weird that the test fails on some combinations of labels. check why.
         label_udf = udf(lambda x: abs(hash(x)) % 2, IntegerType())
-        image_df = getSampleImageDF()
-        train_df = image_df.withColumn("label", label_udf(image_df["filePath"]))
+        train_df = self.imageDF.withColumn("label", label_udf(self.imageDF["filePath"]))
 
         lrModel = pipeline.fit(train_df)
         # see if we at least get the training examples right.
-        # with 5 examples and 131k features, it ought to.
+        # with 5 examples and e.g. 131k features (for InceptionV3), it ought to.
         pred_df_collected = lrModel.transform(train_df).collect()
         for row in pred_df_collected:
             self.assertEqual(int(row.prediction), row.label)
+
+
+class NamedImageTransformerInceptionV3Test(NamedImageTransformerBaseTestCase):
+
+    __test__ = True
+    name = "InceptionV3"
+

--- a/python/tests/transformers/named_image_test.py
+++ b/python/tests/transformers/named_image_test.py
@@ -23,9 +23,10 @@ from pyspark.sql.functions import udf
 from pyspark.sql.types import IntegerType, StructType, StructField
 
 from sparkdl.image import imageIO
+import sparkdl.transformers.keras_applications as keras_apps
 from sparkdl.transformers.named_image import (DeepImagePredictor, DeepImageFeaturizer,
                                               _buildTFGraphForName)
-from sparkdl.transformers.utils import InceptionV3Constants
+#from sparkdl.transformers.utils import InceptionV3Constants
 from ..tests import SparkDLTestCase
 from .image_utils import getSampleImageDF, getSampleImageList
 
@@ -139,7 +140,7 @@ class NamedImageTransformerImagenetTest(SparkDLTestCase):
         collected = transformed_df.collect()
         for row in collected:
             predictions = row[output_col]
-            self.assertEqual(len(predictions), InceptionV3Constants.NUM_OUTPUT_FEATURES)
+            self.assertEqual(len(predictions), keras_apps.InceptionV3Model().numOutputFeatures())
             # TODO: actually check the value of the output to see if they are reasonable
             # e.g. -- compare to just running with keras.
 


### PR DESCRIPTION
DeepImageFeaturizer/Predictor currently has InceptionV3. We want to add other pre-trained models available from Keras. Here is a simple clean way to add them. This PR adds the light wrappers around models and tests for the existing InceptionV3 model. In the next PR we can add all the models and some control over how extensively to run the tests.

The code to use the various Keras pre-trained model is basically the same so it is captured here under KerasApplicationModel.getModelData. See [https://keras.io/applications](https://keras.io/applications).

The `ModelData` interface between the classes is a bit fragile, but seems okay for now...
