### PR TITLE
Report only coverage information of our package

### DIFF
--- a/python/run-tests.sh
+++ b/python/run-tests.sh
@@ -103,7 +103,7 @@ do
   # The grep below is a horrible hack for spark 1.x: we manually remove some log lines to stay below the 4MB log limit on Travis.
   $PYSPARK_DRIVER_PYTHON \
       -m "nose" \
-      --with-coverage \
+      --with-coverage --cover-package=sparkdl \
       --nologcapture \
       -v --exe "$noseOptions" \
       2>&1 | grep -vE "INFO (ParquetOutputFormat|SparkContext|ContextCleaner|ShuffleBlockFetcherIterator|MapOutputTrackerMaster|TaskSetManager|Executor|MemoryStore|CacheManager|BlockManager|DAGScheduler|PythonRDD|TaskSchedulerImpl|ZippedPartitionsRDD2)";

--- a/python/tests/tests.py
+++ b/python/tests/tests.py
@@ -14,6 +14,7 @@
 #
 
 import sys
+import sparkdl
 
 if sys.version_info[:2] <= (2, 6):
     try:


### PR DESCRIPTION
This should suppress test coverage log for external packages.

Documentation
http://nose.readthedocs.io/en/latest/plugins/cover.html#cmdoption-cover-package

Now the Travis CI log is much shorter (https://travis-ci.org/databricks/spark-deep-learning/jobs/252104462)