### PR TITLE
Update DLP to use new RC of tensorframes (v0.2.9-rc3)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ sparkComponents ++= Seq("mllib-local", "mllib", "sql")
 
 // add any Spark Package dependencies using spDependencies.
 // e.g. spDependencies += "databricks/spark-avro:0.1"
-spDependencies += s"databricks/tensorframes:0.2.9-rc0-s_${scalaMajorVersion}"
+spDependencies += s"databricks/tensorframes:0.2.9-rc1-s_${scalaMajorVersion}"
 
 
 // These versions are ancient, but they cross-compile around scala 2.10 and 2.11.

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ sparkComponents ++= Seq("mllib-local", "mllib", "sql")
 
 // add any Spark Package dependencies using spDependencies.
 // e.g. spDependencies += "databricks/spark-avro:0.1"
-spDependencies += s"databricks/tensorframes:0.2.8-s_${scalaMajorVersion}"
+spDependencies += s"databricks/tensorframes:0.2.9-rc0-s_${scalaMajorVersion}"
 
 
 // These versions are ancient, but they cross-compile around scala 2.10 and 2.11.

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ sparkComponents ++= Seq("mllib-local", "mllib", "sql")
 
 // add any Spark Package dependencies using spDependencies.
 // e.g. spDependencies += "databricks/spark-avro:0.1"
-spDependencies += s"databricks/tensorframes:0.2.9-rc1-s_${scalaMajorVersion}"
+spDependencies += s"databricks/tensorframes:0.2.9-rc2-s_${scalaMajorVersion}"
 
 
 // These versions are ancient, but they cross-compile around scala 2.10 and 2.11.

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ sparkComponents ++= Seq("mllib-local", "mllib", "sql")
 
 // add any Spark Package dependencies using spDependencies.
 // e.g. spDependencies += "databricks/spark-avro:0.1"
-spDependencies += s"databricks/tensorframes:0.2.9-rc2-s_${scalaMajorVersion}"
+spDependencies += s"databricks/tensorframes:0.2.9-rc3-s_${scalaMajorVersion}"
 
 
 // These versions are ancient, but they cross-compile around scala 2.10 and 2.11.

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -9,3 +9,4 @@ pygments==2.2.0
 tensorflow==1.3.0
 pandas==0.19.0
 six==1.10.0
+cython==0.23

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,11 +1,11 @@
 # This file should list any python package dependencies.
-coverage==4.4.1
-h5py==2.7.0
-keras==2.0.4
-nose==1.3.7  # for testing
-numpy==1.13.1
-pillow==4.1.1
-pygments==2.2.0
+coverage>=4.4.1
+h5py>=2.7.0
+keras>=2.0.4
+nose>=1.3.7  # for testing
+numpy>=1.11.2
+pillow>=4.1.1
+pygments>=2.2.0
 tensorflow==1.3.0
-pandas==0.19.1
-six==1.10.0
+pandas>=0.19.1
+six>=1.10.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,7 +6,7 @@ nose==1.3.7  # for testing
 numpy==1.11.2
 pillow==4.1.1
 pygments==2.2.0
-cython==0.23
+cython==0.23.0
 tensorflow==1.3.0
 pandas==0.19.0
 six==1.10.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,7 +4,7 @@ h5py>=2.7.0
 keras>=2.0.4
 nose>=1.3.7  # for testing
 numpy>=1.11.2
-pillow>=4.1.1
+pillow>=4.1.1,<4.2
 pygments>=2.2.0
 tensorflow==1.3.0
 pandas>=0.19.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,7 +6,7 @@ nose==1.3.7  # for testing
 numpy==1.11.2
 pillow==4.1.1
 pygments==2.2.0
+cython==0.23
 tensorflow==1.3.0
 pandas==0.19.0
 six==1.10.0
-cython==0.23

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
 # This file should list any python package dependencies.
 coverage>=4.4.1
 h5py>=2.7.0
-keras==2.0.4
+keras>=2.0.4
 nose>=1.3.7  # for testing
 numpy>=1.11.2
 pillow>=4.1.1,<4.2

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,7 +6,6 @@ nose==1.3.7  # for testing
 numpy==1.11.2
 pillow==4.1.1
 pygments==2.2.0
-cython==0.23.0
 tensorflow==1.3.0
 pandas==0.19.1
 six==1.10.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,5 +6,6 @@ nose==1.3.7  # for testing
 numpy==1.11.2
 pillow==4.1.1
 pygments==2.2.0
-tensorflow==1.1.0
+tensorflow==1.3.0
+pandas==0.19.0
 six==1.10.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,5 +8,5 @@ pillow==4.1.1
 pygments==2.2.0
 cython==0.23.0
 tensorflow==1.3.0
-pandas==0.19.0
+pandas==0.19.1
 six==1.10.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
 # This file should list any python package dependencies.
 coverage>=4.4.1
 h5py>=2.7.0
-keras>=2.0.4
+keras==2.0.4 # NOTE: this package has only been tested with keras 2.0.4 and may not work with other releases
 nose>=1.3.7  # for testing
 numpy>=1.11.2
 pillow>=4.1.1,<4.2

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
 # This file should list any python package dependencies.
 coverage>=4.4.1
 h5py>=2.7.0
-keras>=2.0.4
+keras==2.0.4
 nose>=1.3.7  # for testing
 numpy>=1.11.2
 pillow>=4.1.1,<4.2

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,7 +3,7 @@ coverage==4.4.1
 h5py==2.7.0
 keras==2.0.4
 nose==1.3.7  # for testing
-numpy==1.11.2
+numpy==1.13.1
 pillow==4.1.1
 pygments==2.2.0
 tensorflow==1.3.0

--- a/python/spark-package-deps.txt
+++ b/python/spark-package-deps.txt
@@ -1,3 +1,3 @@
 # This file should list any spark package dependencies as:
 # :package_name==:version   e.g. databricks/spark-csv==0.1
-databricks/tensorframes==0.2.9-rc0
+databricks/tensorframes==0.2.9-rc1

--- a/python/spark-package-deps.txt
+++ b/python/spark-package-deps.txt
@@ -1,3 +1,3 @@
 # This file should list any spark package dependencies as:
 # :package_name==:version   e.g. databricks/spark-csv==0.1
-databricks/tensorframes==0.2.8
+databricks/tensorframes==0.2.9-rc0

--- a/python/spark-package-deps.txt
+++ b/python/spark-package-deps.txt
@@ -1,3 +1,3 @@
 # This file should list any spark package dependencies as:
 # :package_name==:version   e.g. databricks/spark-csv==0.1
-databricks/tensorframes==0.2.9-rc2
+databricks/tensorframes==0.2.9-rc3

--- a/python/spark-package-deps.txt
+++ b/python/spark-package-deps.txt
@@ -1,3 +1,3 @@
 # This file should list any spark package dependencies as:
 # :package_name==:version   e.g. databricks/spark-csv==0.1
-databricks/tensorframes==0.2.9-rc1
+databricks/tensorframes==0.2.9-rc2

--- a/python/tests/graph/test_builder.py
+++ b/python/tests/graph/test_builder.py
@@ -58,9 +58,13 @@ class GraphFunctionWithIsolatedSessionTest(SparkDLTestCase):
 
         self.assertEqual(z_ref, z_tgt)
 
-        # Version texts are not essential part of the graph, ignore them
-        gdef_ref.ClearField("versions")
-        gfn.graph_def.ClearField("versions")
+        # Remove all fields besides "node" from the graph definition, since we only
+        # care that the nodes are equal
+        # TODO(sid.murching) find a cleaner way of removing all fields besides "node"
+        nonessentialFields = ["versions", "version", "library"]
+        for fieldName in nonessentialFields:
+            gdef_ref.ClearField(fieldName)
+            gfn.graph_def.ClearField(fieldName)
 
         # The GraphDef contained in the GraphFunction object
         # should be the same as that in the one exported directly from TensorFlow session

--- a/python/tests/graph/test_pieces.py
+++ b/python/tests/graph/test_pieces.py
@@ -120,9 +120,6 @@ class GraphPiecesTest(SparkDLTestCase):
 
             _preproc_img_list = []
             for fpath in img_fpaths:
-                print("@SID target_size:  " + target_size)
-                print("@SID target_size deconstructed: %s, %s"%(target_size[0], target_size[1]))
-                print("@SID types: (%s, %s)"%(type(target_size[0]), type(target_size[1])))
                 img = load_img(fpath, target_size=target_size)
                 # WARNING: must apply expand dimensions first, or ResNet50 preprocessor fails
                 img_arr = np.expand_dims(img_to_array(img), axis=0)

--- a/python/tests/graph/test_pieces.py
+++ b/python/tests/graph/test_pieces.py
@@ -120,6 +120,9 @@ class GraphPiecesTest(SparkDLTestCase):
 
             _preproc_img_list = []
             for fpath in img_fpaths:
+                print("@SID target_size:  " + target_size)
+                print("@SID target_size deconstructed: %s, %s"%(target_size[0], target_size[1]))
+                print("@SID types: (%s, %s)"%(type(target_size[0]), type(target_size[1])))
                 img = load_img(fpath, target_size=target_size)
                 # WARNING: must apply expand dimensions first, or ResNet50 preprocessor fails
                 img_arr = np.expand_dims(img_to_array(img), axis=0)


### PR DESCRIPTION
This PR is intended to QA the new RC of tensorframes, checking that packages that depend on it (e.g. deep learning pipelines) still work.