### PR TITLE
Add support for Reading GIF files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.log
 *.pyc
 build/*.jar
+.coverage
 
 docs/_site
 docs/api
@@ -17,6 +18,9 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+
+# spark
+metastore_db
 
 # intellij
 .idea/

--- a/python/sparkdl/image/imageIO.py
+++ b/python/sparkdl/image/imageIO.py
@@ -34,6 +34,10 @@ imageSchema = StructType([StructField("mode", StringType(), False),
                           StructField("nChannels", IntegerType(), False),
                           StructField("data", BinaryType(), False)])
 
+gifSchema = StructType([StructField("filePath", StringType(), False),
+                        StructField("frameNum", IntegerType(), True),
+                        StructField("gifFrame", imageSchema, True)])
+
 
 # ImageType class for holding metadata about images stored in DataFrames.
 # fields:
@@ -304,9 +308,6 @@ def readGifs(gifDirectory, numPartition=None):
 
 
 def _readGifs(gifDirectory, numPartition, sc):
-    schema = StructType([StructField("filePath", StringType(), False),
-                         StructField("frameNum", IntegerType(), True),
-                         StructField("gifFrame", imageSchema, True)])
     gifsRDD = filesToRDD(sc, gifDirectory, numPartitions=numPartition)
     framesRDD = gifsRDD.flatMap(lambda x: [(x[0], i, frame) for (i, frame) in _decodeGif(x[1])])
-    return framesRDD.toDF(schema)
+    return framesRDD.toDF(gifSchema)

--- a/python/sparkdl/image/imageIO.py
+++ b/python/sparkdl/image/imageIO.py
@@ -213,7 +213,7 @@ def _decodeGif(gifData):
     except IOError:
         return [(None, None)]
 
-    if img.tile and img.tile[0] and img.tile[0][0] == "gif":
+    if img.format.lower() == "gif":
         mode = pilModeLookup["RGB"]
     else:
         warn("Image file does not appear to be a GIF")
@@ -224,7 +224,8 @@ def _decodeGif(gifData):
     mypalette = img.getpalette()
     try:
         while True:
-            img.putpalette(mypalette)
+            if not img.getpalette() and mypalette:
+                img.putpalette(mypalette)
             newImg = Image.new("RGB", img.size)
             newImg.paste(img)
 

--- a/python/sparkdl/image/imageIO.py
+++ b/python/sparkdl/image/imageIO.py
@@ -216,8 +216,7 @@ def _decodeGif(gifData):
     if img.tile and img.tile[0] and img.tile[0][0] == "gif":
         mode = pilModeLookup["RGB"]
     else:
-        msg = "GIFs are not supported with image mode: {mode}"
-        warn(msg.format(mode=img.mode))
+        warn("Image file does not appear to be a GIF")
         return [(None, None)]
 
     frames = []
@@ -228,7 +227,6 @@ def _decodeGif(gifData):
             img.putpalette(mypalette)
             newImg = Image.new("RGB", img.size)
             newImg.paste(img)
-            newImg.show()
 
             newImgArray = np.asarray(newImg)
             newImage = imageArrayToStruct(newImgArray, mode.sparkMode)
@@ -252,7 +250,7 @@ def filesToRDD(sc, path, numPartitions=None):
     :param sc: SparkContext.
     :param path: str, path to files.
     :param numPartitions: int, number or partitions to use for reading files.
-    :return: RDD, with columns: (filePath: str, fileData: BinaryType)
+    :return: RDD tuple of: (filePath: str, fileData: BinaryType)
     """
     numPartitions = numPartitions or sc.defaultParallelism
     rdd = sc.binaryFiles(path, minPartitions=numPartitions).repartition(numPartitions)


### PR DESCRIPTION
We have been using this library over at [GIPHY|https://github.com/Giphy] and love it.  We had to adapt it to work with GIFs, and we thought we'd share some of the changes with the community.  It includes:

- [x] `readGifs` function that reads a directory of GIFs and splits them out into individual frames/images that can be fed into `InceptionV3` and other models.
- [x] supporting unit tests mimicking tests in `TestReadImages`
- [x] updates to `.gitignore`