### PR TITLE
Add ResNet50 to DeepImageFeaturizer

### DIFF
--- a/python/sparkdl/transformers/keras_applications.py
+++ b/python/sparkdl/transformers/keras_applications.py
@@ -43,7 +43,6 @@ class KerasApplicationModel:
         with sess.as_default():
             K.set_learning_phase(0)
             inputImage = imageInputPlaceholder(nChannels=3)
-            # PROBLEM: the type of preprocessed here i think doesn't match between InceptionV3/Xception and Resnet50
             preprocessed = self.preprocess(inputImage)
             model = self.model(preprocessed, featurize)
         return dict(inputTensorName=inputImage.name,

--- a/python/sparkdl/transformers/keras_applications.py
+++ b/python/sparkdl/transformers/keras_applications.py
@@ -121,11 +121,12 @@ class ResNet50Model(KerasApplicationModel):
 
 def _imagenet_preprocess_input(x, input_shape):
     """
-    For ResNet50, VGG models. For InceptionV3 and Xception use the keras one
-    for them as they work okay for tf.Tensor. The following was translated to tf ops from
+    For ResNet50, VGG models. For InceptionV3 and Xception it's okay to use the
+    keras version (e.g. InceptionV3.preprocess_input) as the code path they hit
+    works okay with tf.Tensor inputs. The following was translated to tf ops from
     https://github.com/fchollet/keras/blob/fb4a0849cf4dc2965af86510f02ec46abab1a6a4/keras/applications/imagenet_utils.py#L52
-    It's a possibility to change the implementation in keras to look like the following, but
-    not doing it for now.
+    It's a possibility to change the implementation in keras to look like the
+    following, but not doing it for now.
     """
     # 'RGB'->'BGR'
     x = x[..., ::-1]

--- a/python/sparkdl/transformers/keras_applications.py
+++ b/python/sparkdl/transformers/keras_applications.py
@@ -16,7 +16,8 @@
 from abc import ABCMeta, abstractmethod
 
 import keras.backend as K
-from keras.applications import inception_v3, xception
+from keras.applications import inception_v3, xception, resnet50
+import numpy as np
 import tensorflow as tf
 
 from sparkdl.transformers.utils import (imageInputPlaceholder, InceptionV3Constants)
@@ -42,6 +43,7 @@ class KerasApplicationModel:
         with sess.as_default():
             K.set_learning_phase(0)
             inputImage = imageInputPlaceholder(nChannels=3)
+            # PROBLEM: the type of preprocessed here i think doesn't match between InceptionV3/Xception and Resnet50
             preprocessed = self.preprocess(inputImage)
             model = self.model(preprocessed, featurize)
         return dict(inputTensorName=inputImage.name,
@@ -104,9 +106,40 @@ class XceptionModel(KerasApplicationModel):
     def _testKerasModel(self, include_top):
         return xception.Xception(weights="imagenet", include_top=include_top)
 
+class ResNet50Model(KerasApplicationModel):
+    def preprocess(self, inputImage):
+        return _imagenet_preprocess_input(inputImage, self.inputShape())
+
+    def model(self, preprocessed, featurize):
+        return resnet50.ResNet50(input_tensor=preprocessed, weights="imagenet",
+                                 include_top=(not featurize))
+
+    def inputShape(self):
+        return (224, 224)
+
+    def _testKerasModel(self, include_top):
+        return resnet50.ResNet50(weights="imagenet", include_top=include_top)
+
+def _imagenet_preprocess_input(x, input_shape):
+    """
+    For ResNet50, VGG models. For InceptionV3 and Xception use the keras one
+    for them as they work okay for tf.Tensor. The following was translated to tf ops from
+    https://github.com/fchollet/keras/blob/fb4a0849cf4dc2965af86510f02ec46abab1a6a4/keras/applications/imagenet_utils.py#L52
+    It's a possibility to change the implementation in keras to look like the following, but
+    not doing it for now.
+    """
+    # 'RGB'->'BGR'
+    x = x[..., ::-1]
+    # Zero-center by mean pixel
+    mean = np.ones(input_shape + (3,), dtype=np.float32)
+    mean[..., 0] = 103.939
+    mean[..., 1] = 116.779
+    mean[..., 2] = 123.68
+    return x - mean
 
 KERAS_APPLICATION_MODELS = {
     "InceptionV3": InceptionV3Model,
-    "Xception": XceptionModel
+    "Xception": XceptionModel,
+    "ResNet50": ResNet50Model,
 }
 

--- a/python/sparkdl/transformers/named_image.py
+++ b/python/sparkdl/transformers/named_image.py
@@ -29,7 +29,7 @@ from sparkdl.param import (
 from sparkdl.transformers.tf_image import TFImageTransformer
 
 
-SUPPORTED_MODELS = ["InceptionV3", "Xception"]
+SUPPORTED_MODELS = ["InceptionV3", "Xception", "ResNet50"]
 
 
 class DeepImagePredictor(Transformer, HasInputCol, HasOutputCol):

--- a/python/tests/transformers/named_image_ResNet50_test.py
+++ b/python/tests/transformers/named_image_ResNet50_test.py
@@ -1,0 +1,21 @@
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from .named_image_test import NamedImageTransformerBaseTestCase
+
+class NamedImageTransformerResNet50Test(NamedImageTransformerBaseTestCase):
+
+    __test__ = True
+    name = "ResNet50"


### PR DESCRIPTION
Adding support for ResNet50 model in DeepImageFeaturizer. It should be pretty trivial to add VGG16 and VGG19 after this (though I am running into heap space problems on my laptop).

To test:
```
$ build/sbt assembly
$ SPARK_HOME=/usr/local/lib/spark-2.1.1-bin-hadoop2.7 PYSPARK_PYTHON=python2 SCALA_VERSION=2.11.8 SPARK_VERSION=2.1.1  python/run-tests.sh python/tests/transformers/named_image_Resnet50_test.py 
```