### PR TITLE
Bump spark-deep-learning version numbers for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,9 @@ registerKerasImageUDF("my_keras_inception_udf", InceptionV3(weights="imagenet"),
 
 ```
 
-### Estimator
-
 ## Releases:
-* 0.1.0 Alpha release
-* 0.2.0 Initial release
+- 0.1.0 Alpha release
+- 0.2.0 release:
+    1. KerasImageFileEstimator API (train a Keras model on image files)
+    2. Scala SQL UDF Support
+    3. Added Xception, Resnet50 models to DeepImageFeaturizer/DeepImagePredictor.

--- a/README.md
+++ b/README.md
@@ -244,4 +244,4 @@ registerKerasImageUDF("my_keras_inception_udf", InceptionV3(weights="imagenet"),
 ### Estimator
 
 ## Releases:
-* 0.1.0 initial release
+* 0.2.0 initial release

--- a/README.md
+++ b/README.md
@@ -244,4 +244,5 @@ registerKerasImageUDF("my_keras_inception_udf", InceptionV3(weights="imagenet"),
 ### Estimator
 
 ## Releases:
-* 0.2.0 initial release
+* 0.1.0 Alpha release
+* 0.2.0 Initial release

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ scalaVersion := scalaVer
 spName := "databricks/spark-deep-learning"
 
 // Don't forget to set the version
-version := s"0.1.0-spark$sparkBranch"
+version := s"0.2.0-spark$sparkBranch"
 
 // All Spark Packages need a license
 licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"))

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,7 +14,7 @@ include:
 
 # These allow the documentation to be updated with newer releases
 # of Spark, Scala, and Mesos.
-SPARKDL_VERSION: 0.1.0
+SPARKDL_VERSION: 0.2.0
 #SCALA_BINARY_VERSION: "2.10"
 #SCALA_VERSION: "2.10.4"
 #MESOS_VERSION: 0.21.0


### PR DESCRIPTION
Update version number from 0.1.0 to 0.2.0 to prep for release.

* Searched for occurrences of "0.1.0" via `git grep --name-only "0.1.0"`, replaced them with 0.2.0