### PR TITLE
Add persistence & test for DeepImageFeaturizer in Scala

### DIFF
--- a/src/main/scala/com/databricks/sparkdl/DeepImageFeaturizer.scala
+++ b/src/main/scala/com/databricks/sparkdl/DeepImageFeaturizer.scala
@@ -23,11 +23,10 @@ import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.param.{Param, ParamMap}
-import org.apache.spark.ml.util.{DefaultParamsWritable, Identifiable}
+import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.apache.spark.sql.functions.{col, udf}
 import org.apache.spark.sql.types.StructType
-
 import org.tensorflow.framework.GraphDef
 import org.tensorframes.{Shape, ShapeDescription}
 import org.tensorframes.impl.DebugRowOps
@@ -126,7 +125,7 @@ class DeepImageFeaturizer(override val uid: String) extends Transformer with Def
   }
 }
 
-object DeepImageFeaturizer {
+object DeepImageFeaturizer extends DefaultParamsReadable[DeepImageFeaturizer] {
   /**
    * The deep image featurizer uses the information provided by named Image model to apply the
    * tensorflow graph, given in NamedImageModel.graph as a GraphDef, to an image column of a

--- a/src/test/scala/com/databricks/sparkdl/DeepImageFeaturizerSuite.scala
+++ b/src/test/scala/com/databricks/sparkdl/DeepImageFeaturizerSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.types.{StructField, StructType}
 import org.scalatest.FunSuite
 
-class DeepImageFeaturizerSuite extends FunSuite with TestSparkContext {
+class DeepImageFeaturizerSuite extends FunSuite with TestSparkContext with DefaultReadWriteTest {
 
   var data: DataFrame = _
 
@@ -117,5 +117,13 @@ class DeepImageFeaturizerSuite extends FunSuite with TestSparkContext {
     assertThrows[IllegalArgumentException] {
       featurizer.setModelName("noSuchModel")
     }
+  }
+
+  test("DeepImageFeaturizer persistence") {
+    val featurizer = new DeepImageFeaturizer()
+      .setModelName("_test")
+      .setInputCol("myInput")
+      .setOutputCol("myOutput")
+    testDefaultReadWrite(featurizer)
   }
 }

--- a/src/test/scala/com/databricks/sparkdl/DefaultReadWriteTest.scala
+++ b/src/test/scala/com/databricks/sparkdl/DefaultReadWriteTest.scala
@@ -1,0 +1,66 @@
+package com.databricks.sparkdl
+
+import java.io.{File, IOException}
+
+import org.scalatest.Suite
+
+import org.apache.spark.ml.param.Params
+import org.apache.spark.ml.util.{Identifiable, MLReader, MLWritable, TempDirectory}
+
+/**
+ * Copied from Spark.
+ *
+ * Trait containing a default persistence test for Estimators/Transformers whose data is stored
+ * entirely in [[org.apache.spark.ml.param.Param]] instances.
+ * */
+trait DefaultReadWriteTest extends TempDirectory { self: Suite =>
+
+  /**
+   * Checks "overwrite" option and params.
+   * This saves to and loads from [[tempDir]], but creates a subdirectory with a random name
+   * in order to avoid conflicts from multiple calls to this method.
+   *
+   * @param instance ML instance to test saving/loading
+   * @param testParams  If true, then test values of Params.  Otherwise, just test overwrite option.
+   * @tparam T ML instance type
+   * @return  Instance loaded from file
+   */
+  def testDefaultReadWrite[T <: Params with MLWritable](
+      instance: T,
+      testParams: Boolean = true): T = {
+    val uid = instance.uid
+    val subdirName = Identifiable.randomUID("test")
+
+    val subdir = new File(tempDir, subdirName)
+    val path = new File(subdir, uid).getPath
+
+    instance.save(path)
+    intercept[IOException] {
+      instance.save(path)
+    }
+    instance.write.overwrite().save(path)
+    val loader = instance.getClass.getMethod("read").invoke(null).asInstanceOf[MLReader[T]]
+    val newInstance = loader.load(path)
+    assert(newInstance.uid === instance.uid)
+    if (testParams) {
+      instance.params.foreach { p =>
+        if (instance.isDefined(p)) {
+          (instance.getOrDefault(p), newInstance.getOrDefault(p)) match {
+            case (Array(values), Array(newValues)) =>
+              assert(values === newValues, s"Values do not match on param ${p.name}.")
+            case (value, newValue) =>
+              assert(value === newValue, s"Values do not match on param ${p.name}.")
+          }
+        } else {
+          assert(!newInstance.isDefined(p), s"Param ${p.name} shouldn't be defined.")
+        }
+      }
+    }
+
+    val load = instance.getClass.getMethod("load", classOf[String])
+    val another = load.invoke(instance, path).asInstanceOf[T]
+    assert(another.uid === instance.uid)
+    another
+  }
+
+}

--- a/src/test/scala/com/databricks/sparkdl/DefaultReadWriteTest.scala
+++ b/src/test/scala/com/databricks/sparkdl/DefaultReadWriteTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Databricks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.databricks.sparkdl
 
 import java.io.{File, IOException}

--- a/src/test/scala/com/databricks/sparkdl/DefaultReadWriteTest.scala
+++ b/src/test/scala/com/databricks/sparkdl/DefaultReadWriteTest.scala
@@ -8,7 +8,8 @@ import org.apache.spark.ml.param.Params
 import org.apache.spark.ml.util.{Identifiable, MLReader, MLWritable, TempDirectory}
 
 /**
- * Copied from Spark.
+ * Copied from Spark (https://github.com/apache/spark/blob/branch-2.2/mllib/src/test/scala/org/
+ * apache/spark/ml/util/DefaultReadWriteTest.scala).
  *
  * Trait containing a default persistence test for Estimators/Transformers whose data is stored
  * entirely in [[org.apache.spark.ml.param.Param]] instances.

--- a/src/test/scala/org/apache/spark/ml/util/TempDirectory.scala
+++ b/src/test/scala/org/apache/spark/ml/util/TempDirectory.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Databricks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.ml.util
 
 import java.io.File

--- a/src/test/scala/org/apache/spark/ml/util/TempDirectory.scala
+++ b/src/test/scala/org/apache/spark/ml/util/TempDirectory.scala
@@ -1,0 +1,34 @@
+package org.apache.spark.ml.util
+
+import java.io.File
+
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+import org.apache.spark.util.Utils
+
+/**
+ * Trait that creates a temporary directory before all tests and deletes it after all.
+ */
+trait TempDirectory extends BeforeAndAfterAll { self: Suite =>
+
+  private var _tempDir: File = _
+
+  /**
+   * Returns the temporary directory as a `File` instance.
+   */
+  protected def tempDir: File = _tempDir
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    _tempDir = Utils.createTempDir(namePrefix = this.getClass.getName)
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      Utils.deleteRecursively(_tempDir)
+    } finally {
+      super.afterAll()
+    }
+  }
+}
+


### PR DESCRIPTION
* Adds persistence for Scala implementation of `DeepImageFeaturizer`. 
  * Since `DeepImageFeaturizer` stores all its data as instances of `org.apache.spark.ml.Param`, all we need to do is extend Spark's default ML persistence traits (`DefaultParamsReadable`, `DefaultParamsWritable`). 
* Adds test for `DeepImageFeaturizer` persistence; we copy over relevant portions of Spark's default ML persistence tests.

See MLlib's [Binarizer](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/feature/Binarizer.scala) and [BinarizerSuite](https://github.com/apache/spark/blob/branch-2.2/mllib/src/test/scala/org/apache/spark/ml/feature/BinarizerSuite.scala#L107) for an example of a similar Transformer/test suite pair.