### PR TITLE
Bugfix: Properly expose KerasTransformer via 'from sparkdl import KerasTransformer'

### DIFF
--- a/python/sparkdl/__init__.py
+++ b/python/sparkdl/__init__.py
@@ -15,6 +15,7 @@
 from .graph.input import TFInputGraph
 from .transformers.keras_image import KerasImageFileTransformer
 from .transformers.named_image import DeepImagePredictor, DeepImageFeaturizer
+from .transformers.keras_tensor import KerasTransformer
 from .transformers.tf_image import TFImageTransformer
 from .transformers.tf_tensor import TFTransformer
 from .transformers.utils import imageInputPlaceholder


### PR DESCRIPTION
Fixes a bug where `KerasTransformer` wasn't imported  in our root __init__.py and so not accessible via `from sparkdl import KerasTransformer`

Tested by building the spark-deep-learning assembly JAR and running a KerasTransformer test against the JAR, using `from sparkdl import KerasTransformer`