### PR TITLE
Persistence for DeepImageFeaturizer (#95)

### DIFF
--- a/python/sparkdl/transformers/named_image.py
+++ b/python/sparkdl/transformers/named_image.py
@@ -157,7 +157,11 @@ class DeepImageFeaturizer(JavaTransformer, JavaMLReadable, JavaMLWritable):
     can be used in a MLlib Pipeline.
     The input image column should be ImageSchema.
     """
-
+    # NOTE: We are not inheriting from HasInput/HasOutput to mirror the scala side. It also helps
+    # us to avoid issue with serialization/deserialization - default values based on uid do not
+    # always get set to correct value on the python side after deserialization. Default values do
+    # not get reset to the jvm side value unless they param value is not set.
+    # See pyspark.ml.wrapper.JavaParams._transfer_params_from_java
     inputCol = Param(Params._dummy(), "inputCol", "input column name.", typeConverter=TypeConverters.toString)
     outputCol = Param(Params._dummy(), "outputCol", "output column name.", typeConverter=TypeConverters.toString)
     modelName = Param(Params._dummy(), "modelName", "A deep learning model name",
@@ -205,7 +209,7 @@ class DeepImageFeaturizer(JavaTransformer, JavaMLReadable, JavaMLWritable):
         return self.getOrDefault(self.modelName)
 
     def setScaleHint(self, value):
-            return self._set(scaleHint=value)
+        return self._set(scaleHint=value)
 
     def getScaleHint(self):
         return self.getOrDefault(self.scaleHint)

--- a/python/sparkdl/transformers/named_image.py
+++ b/python/sparkdl/transformers/named_image.py
@@ -150,7 +150,7 @@ class _DeepImageFeaturizerReader(JavaMLReader):
         return "com.databricks.sparkdl.DeepImageFeaturizer"
 
 
-class DeepImageFeaturizer(JavaTransformer, JavaMLReadable, JavaMLWritable, HasInputCol, HasOutputCol):
+class DeepImageFeaturizer(JavaTransformer, JavaMLReadable, JavaMLWritable):
     """
     Applies the model specified by its popular name, with its prediction layer(s) chopped off,
     to the image column in DataFrame. The output is a MLlib Vector so that DeepImageFeaturizer
@@ -158,9 +158,10 @@ class DeepImageFeaturizer(JavaTransformer, JavaMLReadable, JavaMLWritable, HasIn
     The input image column should be ImageSchema.
     """
 
+    inputCol = Param(Params._dummy(), "inputCol", "input column name.", typeConverter=TypeConverters.toString)
+    outputCol = Param(Params._dummy(), "outputCol", "output column name.", typeConverter=TypeConverters.toString)
     modelName = Param(Params._dummy(), "modelName", "A deep learning model name",
                       typeConverter=SparkDLTypeConverters.buildSupportedItemConverter(SUPPORTED_MODELS))
-
     scaleHint = Param(Params._dummy(), "scaleHint", "Hint which algorhitm to use for image resizing",
                       typeConverter=_scaleHintConverter)
 
@@ -171,7 +172,6 @@ class DeepImageFeaturizer(JavaTransformer, JavaMLReadable, JavaMLWritable, HasIn
         """
         super(DeepImageFeaturizer, self).__init__()
         self._java_obj = self._new_java_obj("com.databricks.sparkdl.DeepImageFeaturizer", self.uid)
-        self._defaultParamMap = {} # discard unwanted defaults from parents
         self._setDefault(scaleHint="SCALE_AREA_AVERAGING")
         kwargs = self._input_kwargs
         self.setParams(**kwargs)
@@ -185,6 +185,18 @@ class DeepImageFeaturizer(JavaTransformer, JavaMLReadable, JavaMLWritable, HasIn
         self._set(**kwargs)
         self._transfer_params_to_java()
         return self
+
+    def setInputCol(selfs, value):
+        return self._set(inputCol=value)
+
+    def getInputCol(self):
+        return self.getOrDefault(self.inputCol)
+
+    def setOutputCol(selfs, value):
+        return self._set(outputCol=value)
+
+    def getOutputCol(self):
+        return self.getOrDefault(self.outputCol)
 
     def setModelName(self, value):
         return self._set(modelName=value)

--- a/python/tests/transformers/named_image_test.py
+++ b/python/tests/transformers/named_image_test.py
@@ -259,7 +259,7 @@ class DeepImageFeaturizerPersistenceTest(SparkDLTempDirTestCase):
         self.assertEqual(transformer0._paramMap, transformer1._paramMap,
                          "Loaded DeepImageFeaturizer instance params (%s) did not match "
                          % str(transformer1._paramMap) +
-                         "original defaults (%s)" % str(transformer0._paramMap))
+                         "original values (%s)" % str(transformer0._paramMap))
         self.assertEqual(transformer0._defaultParamMap, transformer1._defaultParamMap,
                          "Loaded DeepImageFeaturizer instance default params (%s) did not match "
                          % str(transformer1._defaultParamMap) +

--- a/python/tests/transformers/named_image_test.py
+++ b/python/tests/transformers/named_image_test.py
@@ -15,10 +15,9 @@
 
 from keras.applications import resnet50
 import numpy as np
+import os
 from PIL import Image
 from scipy import spatial
-from shutil import rmtree
-import tempfile
 import tensorflow as tf
 
 from pyspark.ml import Pipeline
@@ -33,7 +32,7 @@ from sparkdl.transformers.named_image import (DeepImagePredictor, DeepImageFeatu
 
 from sparkdl.image.image import ImageSchema
 
-from ..tests import SparkDLTestCase
+from ..tests import SparkDLTestCase, SparkDLTempDirTestCase
 from .image_utils import getSampleImageDF
 from.image_utils import getImageFiles
 
@@ -244,29 +243,24 @@ class NamedImageTransformerBaseTestCase(SparkDLTestCase):
             self.assertEqual(int(row.prediction), row.label)
 
 
-class DeepImageFeaturizerPersistenceTest(SparkDLTestCase):
+class DeepImageFeaturizerPersistenceTest(SparkDLTempDirTestCase):
     def test_inception(self):
         transformer0 = DeepImageFeaturizer(inputCol='image', modelName="InceptionV3",
-                                          outputCol="features0", scaleHint="SCALE_FAST")
-        path = tempfile.mkdtemp()
-        dst_path = path + "/featurizer"
+                                           outputCol="features0", scaleHint="SCALE_FAST")
+        dst_path = os.path.join(self.tempdir, "featurizer")
         transformer0.save(dst_path)
         transformer1 = DeepImageFeaturizer.load(dst_path)
         self.assertEqual(transformer0.uid, transformer1.uid)
         self.assertEqual(type(transformer0.uid), type(transformer1.uid))
-        self.assertEqual(transformer1.uid, transformer1.scaleHint.parent,
-                         "Loaded DeepImageFeaturizer instance uid (%s) did not match Param's uid (%s)"
-                         % (transformer1.uid, transformer1.scaleHint.parent))
+        for x in transformer0._paramMap.keys():
+            self.assertEqual(transformer1.uid, x.parent,
+                             "Loaded DeepImageFeaturizer instance uid (%s) did not match Param's uid (%s)"
+                             % (transformer1.uid, transformer1.scaleHint.parent))
         self.assertEqual(transformer0._paramMap, transformer1._paramMap,
                          "Loaded DeepImageFeaturizer instance params (%s) did not match "
-                         % str(transformer1._defaultParamMap) +
-                         "original defaults (%s)" % str(transformer0._defaultParamMap))
+                         % str(transformer1._paramMap) +
+                         "original defaults (%s)" % str(transformer0._paramMap))
         self.assertEqual(transformer0._defaultParamMap, transformer1._defaultParamMap,
                          "Loaded DeepImageFeaturizer instance default params (%s) did not match "
                          % str(transformer1._defaultParamMap) +
                          "original defaults (%s)" % str(transformer0._defaultParamMap))
-        try:
-            rmtree(path)
-        except OSError:
-            pass
-


### PR DESCRIPTION
Enabled persistence for DeepImageFeaturizer in Python: inherited MLWriteable and MLReadable plus a bit of extra code to make it work (MLLib code has some hardcoded paths which don't work for deep learning pipelines. + a bug we discovered with the default persistence code.)