### PR TITLE
Add support for FloatType, IntegerType and LongType inputs to TFTransformer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.coverage
+*test_net_cached.pb
 *.class
 *.log
 *.pyc

--- a/python/sparkdl/transformers/tf_tensor.py
+++ b/python/sparkdl/transformers/tf_tensor.py
@@ -20,7 +20,7 @@ from tensorflow.python.tools import optimize_for_inference_lib as infr_opt
 import tensorframes as tfs
 
 from pyspark.ml import Transformer
-from pyspark.sql.types import BooleanType
+from pyspark.sql.types import DoubleType
 
 from sparkdl.graph.builder import GraphFunction
 import sparkdl.graph.utils as tfx

--- a/python/sparkdl/transformers/tf_tensor.py
+++ b/python/sparkdl/transformers/tf_tensor.py
@@ -88,6 +88,13 @@ class TFTransformer(Transformer, HasTFInputGraph, HasTFHParams, HasInputMapping,
                                                placeholder_types)
 
     def _transform(self, dataset):
+        if len([field for field in dataset.schema if field.dataType == DoubleType()]) > 0:
+            logger.warn("Detected DoubleType columns in dataframe passed to transform(). In "
+                        "Deep Learning Pipelines 1.0 and above, DoubleType columns can only be "
+                        "fed to input tensors of type tf.float64. To feed dataframe data to "
+                        "tensors of other types (e.g. tf.float32, tf.int32, tf.int64), use the "
+                        "corresponding Spark SQL data types (FloatType, IntegerType, LongType).")
+
         graph_def = self._optimize_for_inference()
         input_mapping = self.getInputMapping()
         output_mapping = self.getOutputMapping()

--- a/python/sparkdl/transformers/tf_tensor.py
+++ b/python/sparkdl/transformers/tf_tensor.py
@@ -20,6 +20,7 @@ from tensorflow.python.tools import optimize_for_inference_lib as infr_opt
 import tensorframes as tfs
 
 from pyspark.ml import Transformer
+from pyspark.sql.types import BooleanType
 
 from sparkdl.graph.builder import GraphFunction
 import sparkdl.graph.utils as tfx

--- a/python/sparkdl/transformers/tf_tensor.py
+++ b/python/sparkdl/transformers/tf_tensor.py
@@ -44,9 +44,6 @@ class TFTransformer(Transformer, HasTFInputGraph, HasTFHParams, HasInputMapping,
     - The transformer is expected to work on blocks of data at the same time.
     """
 
-    # Name scope used for cast/placeholder ops added to the user-specified TF graph by Sparkdl
-    SPARKDL_OP_SCOPE = "sparkdl_ops"
-
     @keyword_only
     def __init__(self, tfInputGraph=None, inputMapping=None, outputMapping=None, tfHParms=None):
         """
@@ -66,65 +63,29 @@ class TFTransformer(Transformer, HasTFInputGraph, HasTFHParams, HasInputMapping,
         # Further conanonicalization, e.g. converting dict to sorted str pairs happens here
         return self._set(**kwargs)
 
-    def _getSparkDlOpName(self, tensor_name):
-        """
-        Given a tensor name, returns the name of the op generating the tensor, prefixed with
-        a special scope indicating that the op has been added by Sparkdl.
-        """
-        op_name = tfx.op_name(tensor_name)
-        return tfx.add_scope_to_name(scope=self.SPARKDL_OP_SCOPE, name=op_name)
-
-    def _addCastOps(self, user_graph_def):
-        """
-        Given a GraphDef object corresponding to a user-specified graph G, creates a copy G'
-        of G with ops injected before each input node. The injected ops allow the input nodes of G'
-        to accept tf.float64 input fed from Spark, casting float64 input into the datatype
-        requested by each input node.
-
-        :return: GraphDef representing the copied, modified graph.
-        """
-        # Load user-specified graph into memory
+    def _get_placeholder_types(self, user_graph_def):
+        """ Returns a list of placeholder type enums for the input nodes """
         user_graph = tf.Graph()
         with user_graph.as_default():
+            # Load user-specified graph into memory, then get the data type of each input node
             tf.import_graph_def(user_graph_def, name="")
-
-        # Build a subgraph containing our injected ops
-        # TODO: Cheap optimization: if all input tensors are of type float64, just do nothing here
-        injected_op_subgraph = tf.Graph()
-        # Maps names of input tensors in our original graph to outputs of the injected-op subgraph
-        input_map = {}
-        with injected_op_subgraph.as_default():
-            with tf.name_scope(self.SPARKDL_OP_SCOPE):
-                for _, orig_tensor_name in self.getInputMapping():
-                    orig_tensor = tfx.get_tensor(orig_tensor_name, user_graph)
-                    # Create placeholder with same shape as original input tensor, but that accepts
-                    # float64 input from Spark.
-                    spark_placeholder = tf.placeholder(tf.float64, shape=orig_tensor.shape,
-                                                       name=tfx.op_name(orig_tensor_name))
-                    # If the original tensor was of type float64, just pass through the Spark input
-                    if orig_tensor.dtype == tf.float64:
-                        input_map[orig_tensor_name] = spark_placeholder
-                    # Otherwise, cast the Spark input to the datatype of the original tensor
-                    else:
-                        input_map[orig_tensor_name] = tf.cast(spark_placeholder,
-                                                              dtype=orig_tensor.dtype)
-            tf.import_graph_def(graph_def=user_graph_def, input_map=input_map, name="")
-        return injected_op_subgraph.as_graph_def(add_shapes=True)
+            res = []
+            for _, tensor_name in self.getInputMapping():
+                placeholder_type = tfx.get_tensor(tensor_name, user_graph).dtype.as_datatype_enum
+                res.append(placeholder_type)
+        return res
 
     def _optimize_for_inference(self):
-        gin = self.getTFInputGraph()
-        # Inject cast ops to convert float64 input fed from Spark into the datatypes of the
-        # Graph's input nodes.
-        graphdef_with_casts = self._addCastOps(self.getTFInputGraph().graph_def)
-
+        graph_def = self.getTFInputGraph().graph_def
+        # Get data types of input placeholders
+        placeholder_types = self._get_placeholder_types(graph_def)
         # Strip away graph nodes not used in computing the tensors with the specified output names
-        input_names = [self._getSparkDlOpName(tnsr_name) for _, tnsr_name in self.getInputMapping()]
+        input_names = [tfx.op_name(tnsr_name) for _, tnsr_name in self.getInputMapping()]
         output_names = [tfx.op_name(tnsr_name) for tnsr_name, _ in self.getOutputMapping()]
-        opt_gdef = infr_opt.optimize_for_inference(graphdef_with_casts,
-                                                   input_names,
-                                                   output_names,
-                                                   tf.float64.as_datatype_enum)
-        return opt_gdef
+        return infr_opt.optimize_for_inference(graph_def,
+                                               input_names,
+                                               output_names,
+                                               placeholder_types)
 
     def _transform(self, dataset):
         graph_def = self._optimize_for_inference()
@@ -137,12 +98,9 @@ class TFTransformer(Transformer, HasTFInputGraph, HasTFHParams, HasInputMapping,
             out_tnsr_op_names = [tfx.op_name(tnsr_name) for tnsr_name, _ in output_mapping]
             # Load graph
             tf.import_graph_def(graph_def=graph_def, name='', return_elements=out_tnsr_op_names)
-
             # Feed dict maps from placeholder name to DF column name
-            feed_dict = {self._getSparkDlOpName(
-                tnsr_name): col_name for col_name, tnsr_name in input_mapping}
+            feed_dict = {tfx.op_name(tnsr_name): col_name for col_name, tnsr_name in input_mapping}
             fetches = [tfx.get_tensor(tnsr_name, graph) for tnsr_name in out_tnsr_op_names]
-
             out_df = tfs.map_blocks(fetches, analyzed_df, feed_dict=feed_dict)
             # We still have to rename output columns
             for tnsr_name, new_colname in output_mapping:

--- a/python/tests/transformers/tf_transformer_test.py
+++ b/python/tests/transformers/tf_transformer_test.py
@@ -76,9 +76,18 @@ def _build_graph(sess):
     Given a session (implicitly), adds nodes of computations
 
     It takes a vector input, with `_tensor_size` columns and returns an float64 scalar.
+    Also takes pairs of (input tensor name, output tensor name)
     """
-    x = tf.placeholder(tf.float64, shape=[None, _tensor_size], name=_tensor_input_name)
-    _ = tf.reduce_max(x, axis=1, name=_tensor_output_name)
+    integer_input = tf.placeholder(tf.int32, shape=[None, _tensor_size], name="integer_tensor")
+    integer_output = tf.reduce_max(x, axis=1, name="integer_output")
+    float_input = tf.placeholder(tf.float32, shape=[None, _tensor_size], name="float_tensor")
+    float_output = tf.reduce_max(x, axis=1, name="float_output")
+    double_input = tf.placeholder(tf.double, shape=[None, _tensor_size], name="double_tensor")
+    double_output = tf.reduce_max(x, axis=1, name="double_output")
+    short_input = tf.placeholder(tf.int16, shape=[None, _tensor_size], name="short_tensor")
+    short_output = tf.reduce_max(x, axis=1, name="short_output")
+    long_input = tf.placeholder(tf.int64, shape=[None, _tensor_size], name="long_tensor")
+    long_output = tf.reduce_max(x, axis=1, name="long_output")
 
 
 def _build_local_features():
@@ -86,6 +95,15 @@ def _build_local_features():
     Build numpy array (i.e. local) features.
     """
     # Build local features and DataFrame from it
+    return {
+        "integer_col": [1, 2, 3],
+        "float_col": [-1.0, -2.0, -3.0],
+        "long_col": [100, 200, 300],
+        "short_col": [4, 5, 6],
+        "double_col": [7.0, 8.0, 9.0]
+    }
+
+
     local_features = []
     np.random.seed(997)
     for idx in range(100):


### PR DESCRIPTION
## What
Currently, TFTransformer accepts only DoubleType input columns, casting Double input into the input type expected by the TF graph. This casting implicitly constrains TFTransformer to support only those TensorFlow input types that can be casted-to from double.

This PR removes the cast-from-double operation in TFTransformer, thereby adding support for FloatType, IntegerType and LongType input columns.

## Why
The changes in this PR will facilitate adding support for BinaryType input columns in a follow-up

## Summary of Changes
* .gitignore: Add files generated by DeepLearningFeaturizer tests and codecov to .gitignore
* tf_tensor.py: Removes extra cast ops added to TF graphs in TFTransformer (**this is a breaking change**; before, users could feed Doubles into tf.float32, tf.int64, tf.int32 tensors). Instead, determines the type of each input tensor (in `_get_placeholder_types`) and replaces it with a placeholder of the same type using the TF `optimize_for_inference` API.
* keras_transformer_test.py: Changed to pass float32 input to Keras graphs (which have float32 input tensors) instead of float64 input.
* tf_transformer_test.py: Modified to test TFTransformer with float, int, and long input columns.