### PR TITLE
Fix KerasImageFileEstimator for model tuning

### DIFF
--- a/python/sparkdl/estimators/keras_image_file_estimator.py
+++ b/python/sparkdl/estimators/keras_image_file_estimator.py
@@ -19,7 +19,6 @@ from __future__ import absolute_import, division, print_function
 
 import threading
 import numpy as np
-from typing import Dict
 
 import pyspark
 from pyspark.ml import Estimator

--- a/python/sparkdl/estimators/keras_image_file_estimator.py
+++ b/python/sparkdl/estimators/keras_image_file_estimator.py
@@ -230,7 +230,7 @@ class KerasImageFileEstimator(Estimator, HasInputCol, HasInputImageNodeName,
 
 
         sc = JVMAPI._curr_sc()
-        paramNameMaps = map(lambda x: {param.name: val for param, val in x.items()}, paramMaps)
+        paramNameMaps = list(map(lambda x: {param.name: val for param, val in x.items()}, paramMaps))
         paramNameMapsRDD = sc.parallelize(paramNameMaps, numSlices=len(paramNameMaps))
 
         # Extract image URI from provided dataset and create features as numpy arrays

--- a/python/sparkdl/param/image_params.py
+++ b/python/sparkdl/param/image_params.py
@@ -111,6 +111,10 @@ class HasOutputMode(Params):
                        "tools in this package.",
                        typeConverter=SparkDLTypeConverters.buildSupportedItemConverter(OUTPUT_MODES))
 
+    def __init__(self):
+        super(HasOutputMode, self).__init__()
+        self._setDefault(outputMode="vector")
+
     def setOutputMode(self, value):
         return self._set(outputMode=value)
 

--- a/python/sparkdl/transformers/keras_image.py
+++ b/python/sparkdl/transformers/keras_image.py
@@ -40,6 +40,7 @@ class KerasImageFileTransformer(Transformer, HasInputCol, HasOutputCol,
                  outputMode="vector")
         """
         super(KerasImageFileTransformer, self).__init__()
+        self._setDefault(outputMode="vector")
         kwargs = self._input_kwargs
         self.setParams(**kwargs)
         self._inputTensor = None
@@ -58,8 +59,7 @@ class KerasImageFileTransformer(Transformer, HasInputCol, HasOutputCol,
 
     def _transform(self, dataset):
         with KSessionWrap() as (sess, keras_graph):
-            graph, inputTensorName, outputTensorName = self._loadTFGraph(sess=sess,
-                                                                         graph=keras_graph)
+            graph, inputTensorName, outputTensorName = self._loadTFGraph(sess=sess, graph=keras_graph)
             image_df = self.loadImagesInternal(dataset, self.getInputCol())
             transformer = TFImageTransformer(channelOrder='RGB', inputCol=self._loadedImageCol(),
                                              outputCol=self.getOutputCol(), graph=graph,

--- a/python/sparkdl/transformers/keras_image.py
+++ b/python/sparkdl/transformers/keras_image.py
@@ -40,7 +40,6 @@ class KerasImageFileTransformer(Transformer, HasInputCol, HasOutputCol,
                  outputMode="vector")
         """
         super(KerasImageFileTransformer, self).__init__()
-        self._setDefault(outputMode="vector")
         kwargs = self._input_kwargs
         self.setParams(**kwargs)
         self._inputTensor = None

--- a/python/sparkdl/transformers/tf_image.py
+++ b/python/sparkdl/transformers/tf_image.py
@@ -83,6 +83,7 @@ class TFImageTransformer(Transformer, HasInputCol, HasOutputCol, HasOutputMode):
         super(TFImageTransformer, self).__init__()
         kwargs = self._input_kwargs
         self.setParams(**kwargs)
+        self._setDefault(inputTensor=IMAGE_INPUT_TENSOR_NAME)
         self.channelOrder = channelOrder
 
     @keyword_only
@@ -94,8 +95,6 @@ class TFImageTransformer(Transformer, HasInputCol, HasOutputCol, HasOutputMode):
                   inputTensor=IMAGE_INPUT_TENSOR_NAME, outputTensor=None,
                   outputMode="vector")
         """
-        self._setDefault(inputTensor=IMAGE_INPUT_TENSOR_NAME)
-        self._setDefault(outputMode="vector")
         kwargs = self._input_kwargs
         return self._set(**kwargs)
 

--- a/python/tests/estimators/test_keras_estimators.py
+++ b/python/tests/estimators/test_keras_estimators.py
@@ -29,6 +29,9 @@ from keras.applications.imagenet_utils import preprocess_input
 
 import pyspark.ml.linalg as spla
 import pyspark.sql.types as sptyp
+import pyspark.sql.functions as F
+from pyspark.ml.evaluation import BinaryClassificationEvaluator
+from pyspark.ml.tuning import CrossValidator, ParamGridBuilder
 
 from sparkdl.estimators.keras_image_file_estimator import KerasImageFileEstimator
 from sparkdl.transformers.keras_image import KerasImageFileTransformer
@@ -61,7 +64,7 @@ class KerasEstimatorsTest(SparkDLTestCase):
             label_inds = label_inds.ravel()
             assert label_inds.shape[0] == cardinality, label_inds.shape
             one_hot_vec = spla.Vectors.dense(label_inds.tolist())
-            _row_struct = {self.input_col: uri, self.label_col: one_hot_vec}
+            _row_struct = {self.input_col: uri, self.one_hot_col: one_hot_vec, self.label_col: float(label)}
             row = sptyp.Row(**_row_struct)
             local_rows.append(row)
 
@@ -69,8 +72,15 @@ class KerasEstimatorsTest(SparkDLTestCase):
         image_uri_df.printSchema()
         return image_uri_df
 
-    def _get_estimator(self, model, optimizer='adam', loss='categorical_crossentropy',
-                       keras_fit_params={'verbose': 1}):
+    def _get_model(self, label_cardinality):
+        # We need a small model so that machines with limited resources can run it
+        model = Sequential()
+        model.add(Flatten(input_shape=(299, 299, 3)))
+        model.add(Dense(label_cardinality))
+        model.add(Activation("softmax"))
+        return model
+
+    def _get_estimator(self, model):
         """
         Create a :py:obj:`KerasImageFileEstimator` from an existing Keras model
         """
@@ -79,40 +89,63 @@ class KerasEstimatorsTest(SparkDLTestCase):
         model.save(model_filename)
         estm = KerasImageFileEstimator(inputCol=self.input_col,
                                        outputCol=self.output_col,
-                                       labelCol=self.label_col,
+                                       labelCol=self.one_hot_col,
                                        imageLoader=_load_image_from_uri,
-                                       kerasOptimizer=optimizer,
-                                       kerasLoss=loss,
-                                       kerasFitParams=keras_fit_params,
+                                       kerasOptimizer='adam',
+                                       kerasLoss='categorical_crossentropy',
                                        modelFile=model_filename)
         return estm
 
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
         self.input_col = 'kerasTestImageUri'
-        self.label_col = 'kerasTestlabel'
+        self.label_col = 'kerasTestLabel'
+        self.one_hot_col = 'kerasTestOneHot'
         self.output_col = 'kerasTestPreds'
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
-    def test_valid_workflow(self):
+    def test_single_training(self):
         # Create image URI dataframe
         label_cardinality = 10
         image_uri_df = self._create_train_image_uris_and_labels(
             repeat_factor=3, cardinality=label_cardinality)
 
-        # We need a small model so that machines with limited resources can run it
-        model = Sequential()
-        model.add(Flatten(input_shape=(299, 299, 3)))
-        model.add(Dense(label_cardinality))
-        model.add(Activation("softmax"))
-
+        model = self._get_model(label_cardinality)
         estimator = self._get_estimator(model)
+        estimator.setKerasFitParams({'verbose': 1})
         self.assertTrue(estimator._validateParams())
+
         transformers = estimator.fit(image_uri_df)
         self.assertEqual(1, len(transformers))
         self.assertIsInstance(transformers[0]['transformer'], KerasImageFileTransformer)
+
+    def test_tuning(self):
+        # Create image URI dataframe
+        label_cardinality = 2
+        image_uri_df = self._create_train_image_uris_and_labels(
+            repeat_factor=3, cardinality=label_cardinality)
+
+        model = self._get_model(label_cardinality)
+        estimator = self._get_estimator(model)
+
+        paramGrid = (
+            ParamGridBuilder()
+            .addGrid(estimator.kerasFitParams, [{"batch_size": 32}, {"batch_size": 64}])
+            .build()
+        )
+
+        bc = BinaryClassificationEvaluator(rawPredictionCol=self.output_col, labelCol=self.label_col)
+        cv = CrossValidator(estimator=estimator, estimatorParamMaps=paramGrid, evaluator=bc, numFolds=2)
+
+        transformers = cv.fit(image_uri_df)
+        self.assertEqual(2, len(transformers))
+        self.assertIsInstance(transformers[0]['transformer'], KerasImageFileTransformer)
+        self.assertIsInstance(transformers[1]['transformer'], KerasImageFileTransformer)
+        df = transformers[0].transform(image_uri_df)
+        self.assertEqual(len(df.collect()), len(image_uri_df.collect()))
+
 
     def test_keras_training_utils(self):
         self.assertTrue(kmutil.is_valid_optimizer('adam'))

--- a/python/tests/estimators/test_keras_estimators.py
+++ b/python/tests/estimators/test_keras_estimators.py
@@ -31,9 +31,11 @@ from pyspark.ml.evaluation import BinaryClassificationEvaluator
 import pyspark.ml.linalg as spla
 from pyspark.ml.tuning import CrossValidator, ParamGridBuilder
 import pyspark.sql.types as sptyp
+
 from sparkdl.estimators.keras_image_file_estimator import KerasImageFileEstimator
 from sparkdl.transformers.keras_image import KerasImageFileTransformer
 import sparkdl.utils.keras_model as kmutil
+
 from ..tests import SparkDLTestCase
 from ..transformers.image_utils import getSampleImagePaths
 

--- a/python/tests/estimators/test_keras_estimators.py
+++ b/python/tests/estimators/test_keras_estimators.py
@@ -140,6 +140,7 @@ class KerasEstimatorsTest(SparkDLTestCase):
 
         transformer = cv.fit(image_uri_df)
         self.assertIsInstance(transformer.bestModel, KerasImageFileTransformer, "best model should be KIFT")
+        self.assertIn('batch_size', transformer.bestModel.getKerasFitParams(), "fit params must be copied")
 
     def test_keras_training_utils(self):
         self.assertTrue(kmutil.is_valid_optimizer('adam'))


### PR DESCRIPTION
* add test for KerasImageFileEstimator used with CrossValidator
* fix pickling issue
* use new `fitMultiple` api and ensure thread safety
* fix tests to reflect new api
* bugfix setDefault
* bugfix HasOutputMode
* remove `_validateParams`
* avoid testing KIFT functionality in KIFEst tests