### PR TITLE
broadcast only tunable parameters

### DIFF
--- a/python/sparkdl/estimators/keras_image_file_estimator.py
+++ b/python/sparkdl/estimators/keras_image_file_estimator.py
@@ -149,7 +149,7 @@ class KerasImageFileEstimator(Estimator, HasInputCol, HasOutputCol, HasLabelCol,
         kwargs = self._input_kwargs
         self.setParams(**kwargs)
         self._tunable_params = [self.kerasOptimizer, self.kerasLoss, self.kerasFitParams,
-                          self.outputCol, self.outputMode]  # model params and output params
+                                self.outputCol, self.outputMode]  # model params and output params
 
     @keyword_only
     def setParams(self, inputCol=None, outputCol=None, outputMode="vector", labelCol=None,


### PR DESCRIPTION
We want to broadcast only the parameters that are used in tuning. Other parameters like "imageLoader" may not be required, and throw error if they are not pickle-able.

To do this, we use the `tunable_params` that we already used to validate params, it has been sent to the constructor, and is also used at the time of broadcast.

To test this, we ran the local tests, could not run the local-cluster test since it does not support pyspark (thanks for help, Lu Wang). To test on cluster, we used Databricks clusters.