### PR TITLE
Add style checks and refactor suggestions

### DIFF
--- a/python/.pylint/accepted.rc
+++ b/python/.pylint/accepted.rc
@@ -131,7 +131,9 @@ disable=print-statement,
         no-member,
         missing-docstring,
         no-init,
-        protected-access
+        protected-access,
+        misplaced-comparison-constant,
+        no-else-return
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -209,7 +211,9 @@ spelling-store-unknown-words=no
 # List of note tags to take in consideration, separated by a comma.
 notes=FIXME,
       XXX,
-      TODO
+      TODO,
+      fixme,
+      todo
 
 
 [SIMILARITIES]

--- a/python/.pylint/accepted.rc
+++ b/python/.pylint/accepted.rc
@@ -130,7 +130,8 @@ disable=print-statement,
         unused-argument, too-many-arguments,
         no-member,
         missing-docstring,
-        no-init
+        no-init,
+        protected-access
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/python/.pylint/accepted.rc
+++ b/python/.pylint/accepted.rc
@@ -1,0 +1,551 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        locally-enabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        unused-argument, too-many-arguments,
+        no-member,
+        missing-docstring,
+        no-init
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+#argument-naming-style=
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+argument-rgx=(([a-z_][a-zA-Z0-9]{2,30})|(__[a-z][a-zA-Z0-9_]+__))$|(([a-z_][a-z0-9_]{2,30})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$
+
+# Naming style matching correct attribute names
+#attr-naming-style=
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+#attr-rgx=(([a-z_][a-zA-Z0-9]{2,30})|(__[a-z][a-zA-Z0-9_]+__))$|(([a-z_][a-z0-9_]{2,30})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+#class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+#class-rgx=
+
+# Naming style matching correct constant names
+#const-naming-style=
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$|logger
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+#function-naming-style=
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+function-rgx=(([a-z_][a-zA-Z0-9]{2,30})|(__[a-z][a-zA-Z0-9_]+__))$|(([a-z_][a-z0-9_]{2,30})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _,
+           x, y, X, Y,
+           sc,
+           df,
+           PIL_decode, PIL_decode_and_resize, PIL_to_imageStruct
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+#inlinevar-rgx=
+
+# Naming style matching correct method names
+#method-naming-style=
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+method-rgx=(([a-z_][a-zA-Z0-9]{2,30})|(__[a-z][a-zA-Z0-9_]+__))$|(([a-z_][a-z0-9_]{2,30})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$|(test_[a-zA-Z0-9_]{1,63})$
+#              [_]camelCase 3-30     |  __camelCase__ >1        |  _snake_case 3-30      | _snake_case | __snake_case__        | test_whatEva_h
+
+# Naming style matching correct module names
+#module-naming-style=
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+module-rgx=([a-z_][a-z0-9_]*)$|([a-z_][a-zA-Z0-9]*)$
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+#variable-naming-style=
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+variable-rgx=(([a-z_][a-zA-Z0-9]{2,30})|(__[a-z][a-zA-Z0-9_]+__))$|(([a-z_][a-z0-9_]{2,30})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=15
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=31
+
+# Maximum number of parents for a class (see R0901).
+max-parents=15
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/python/.pylint/accepted.rc
+++ b/python/.pylint/accepted.rc
@@ -356,7 +356,7 @@ argument-rgx=(([a-z_][a-zA-Z0-9]{2,30})|(__[a-z][a-zA-Z0-9_]+__))$|(([a-z_][a-z0
 
 # Regular expression matching correct attribute names. Overrides attr-naming-
 # style
-#attr-rgx=(([a-z_][a-zA-Z0-9]{2,30})|(__[a-z][a-zA-Z0-9_]+__))$|(([a-z_][a-z0-9_]{2,30})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$
+attr-rgx=(([a-z_][a-zA-Z0-9]{2,30})|(__[a-z][a-zA-Z0-9_]+__))$|(([a-z_][a-z0-9_]{2,30})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,

--- a/python/.pylint/accepted.rc
+++ b/python/.pylint/accepted.rc
@@ -133,7 +133,8 @@ disable=print-statement,
         no-init,
         protected-access,
         misplaced-comparison-constant,
-        no-else-return
+        no-else-return,
+        fixme
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/python/.pylint/suggested.rc
+++ b/python/.pylint/suggested.rc
@@ -1,0 +1,547 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        locally-enabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        unused-argument, too-many-arguments,
+        no-member 
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+#argument-naming-style=
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+argument-rgx=(([a-z_][a-zA-Z0-9]{2,30})|(__[a-z][a-zA-Z0-9_]+__))$|(([a-z_][a-z0-9_]{2,30})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$
+
+# Naming style matching correct attribute names
+#attr-naming-style=
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+#attr-rgx=(([a-z_][a-zA-Z0-9]{2,30})|(__[a-z][a-zA-Z0-9_]+__))$|(([a-z_][a-z0-9_]{2,30})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+#class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+#class-rgx=
+
+# Naming style matching correct constant names
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+#function-naming-style=
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+function-rgx=(([a-z_][a-zA-Z0-9]{2,30})|(__[a-z][a-zA-Z0-9_]+__))$|(([a-z_][a-z0-9_]{2,30})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$
+
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _,
+           x, y, X, Y,
+           sc
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+#inlinevar-rgx=
+
+# Naming style matching correct method names
+#method-naming-style=
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+method-rgx=(([a-z_][a-zA-Z0-9]{2,30})|(__[a-z][a-zA-Z0-9_]+__))$|(([a-z_][a-z0-9_]{2,30})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+#variable-naming-style=
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+variable-rgx=(([a-z_][a-zA-Z0-9]{2,30})|(__[a-z][a-zA-Z0-9_]+__))$|(([a-z_][a-z0-9_]{2,30})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=15
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=31
+
+# Maximum number of parents for a class (see R0901).
+max-parents=15
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/python/sparkdl/__init__.py
+++ b/python/sparkdl/__init__.py
@@ -22,6 +22,6 @@ from .transformers.utils import imageInputPlaceholder
 from .estimators.keras_image_file_estimator import KerasImageFileEstimator
 
 __all__ = [
-    'imageType', 'TFImageTransformer', 'TFInputGraph', 'TFTransformer',
-    'DeepImagePredictor', 'DeepImageFeaturizer', 'KerasImageFileTransformer', 'KerasTransformer',
+    'TFImageTransformer', 'TFInputGraph', 'TFTransformer', 'DeepImagePredictor',
+    'DeepImageFeaturizer', 'KerasImageFileTransformer', 'KerasTransformer',
     'imageInputPlaceholder', 'KerasImageFileEstimator']

--- a/python/sparkdl/estimators/keras_image_file_estimator.py
+++ b/python/sparkdl/estimators/keras_image_file_estimator.py
@@ -34,6 +34,7 @@ import sparkdl.utils.keras_model as kmutil
 __all__ = ['KerasImageFileEstimator']
 
 
+# pylint: disable=too-few-public-methods
 class _ThreadSafeIterator(object):
     """
     Utility iterator class used by KerasImageFileEstimator.fitMultiple to serve models in a thread
@@ -264,7 +265,7 @@ class KerasImageFileEstimator(Estimator, HasInputCol, HasOutputCol, HasLabelCol,
                      existence of a sufficiently large (and writable) file system, users are
                      advised to not train too many models in a single Spark job.
         """
-        [self._validateParams(pm) for pm in paramMaps]
+        assert all([self._validateParams(pm) for pm in paramMaps])
 
         def _name_value_map(paramMap):
             """takes a dictionary {param -> value} and returns a map of {param.name -> value}"""

--- a/python/sparkdl/estimators/keras_image_file_estimator.py
+++ b/python/sparkdl/estimators/keras_image_file_estimator.py
@@ -265,7 +265,7 @@ class KerasImageFileEstimator(Estimator, HasInputCol, HasOutputCol, HasLabelCol,
                      existence of a sufficiently large (and writable) file system, users are
                      advised to not train too many models in a single Spark job.
         """
-        assert all([self._validateParams(pm) for pm in paramMaps])
+        _ = [self._validateParams(pm) for pm in paramMaps]
 
         def _name_value_map(paramMap):
             """takes a dictionary {param -> value} and returns a map of {param.name -> value}"""

--- a/python/sparkdl/graph/builder.py
+++ b/python/sparkdl/graph/builder.py
@@ -27,7 +27,6 @@ import sparkdl.graph.utils as tfx
 
 logger = logging.getLogger('sparkdl')
 
-# pylint: disable=fixme
 
 class IsolatedSession(object):
     """
@@ -84,7 +83,8 @@ class IsolatedSession(object):
 
         :param inputs: list, graph elements representing the inputs
         :param outputs: list, graph elements representing the outputs
-        :param strip_and_freeze: bool, should we remove unused part of the graph and free its values
+        :param strip_and_freeze: bool, should we remove unused part of the graph and freeze its
+        values
         """
         if strip_and_freeze:
             gdef = tfx.strip_and_freeze_until(outputs, self.graph, self.sess)

--- a/python/sparkdl/graph/builder.py
+++ b/python/sparkdl/graph/builder.py
@@ -27,6 +27,7 @@ import sparkdl.graph.utils as tfx
 
 logger = logging.getLogger('sparkdl')
 
+# pylint: disable=fixme
 
 class IsolatedSession(object):
     """
@@ -256,7 +257,8 @@ class GraphFunction(object):
 
             for idx, (scope, gfn) in enumerate(functions):
                 # Give a scope to each function to avoid name conflict
-                if scope is None or len(scope.strip()) == 0:
+                if scope is None or len(scope.strip()) == 0:    # pylint: disable=len-as-condition
+                    # TODO: refactor above and test: if not (scope and scope.strip())
                     scope = 'GFN-BLK-{}'.format(idx)
                 _msg = 'merge: stage {}, scope {}'.format(idx, scope)
                 logger.info(_msg)

--- a/python/sparkdl/graph/builder.py
+++ b/python/sparkdl/graph/builder.py
@@ -16,11 +16,11 @@
 import logging
 import os
 import shutil
-import six
 from tempfile import mkdtemp
 
 import keras.backend as K
 from keras.models import Model as KerasModel, load_model
+import six
 import tensorflow as tf
 
 import sparkdl.graph.utils as tfx
@@ -83,7 +83,7 @@ class IsolatedSession(object):
 
         :param inputs: list, graph elements representing the inputs
         :param outputs: list, graph elements representing the outputs
-        :param strip_and_freeze: bool, should we remove unused part of the graph and freee its values
+        :param strip_and_freeze: bool, should we remove unused part of the graph and free its values
         """
         if strip_and_freeze:
             gdef = tfx.strip_and_freeze_until(outputs, self.graph, self.sess)
@@ -100,9 +100,11 @@ class IsolatedSession(object):
 
         .. _a link: https://www.tensorflow.org/api_docs/python/tf/import_graph_def
 
-        :param gfn: GraphFunction, an object representing a TensorFlow graph and its inputs and outputs
+        :param gfn: GraphFunction, an object representing a TensorFlow graph and its inputs and
+        outputs
         :param input_map: dict, mapping from input names to existing graph elements
-        :param prefix: str, the scope for all the variables in the :py:class:`GraphFunction` elements
+        :param prefix: str, the scope for all the variables in the :py:class:`GraphFunction`
+        elements
 
                        .. _a link: https://www.tensorflow.org/programmers_guide/variable_scope
 
@@ -142,7 +144,8 @@ class GraphFunction(object):
     """
     Represent a TensorFlow graph with its GraphDef, input and output operation names.
 
-    :param graph_def: GraphDef, a static ProtocolBuffer object holding informations of a TensorFlow graph
+    :param graph_def: GraphDef, a static ProtocolBuffer object holding information of a
+    TensorFlow graph
     :param input_names: names to the input graph elements (must be of Placeholder type)
     :param output_names: names to the output graph elements
     """
@@ -179,7 +182,8 @@ class GraphFunction(object):
         """
         Build a GraphFunction from a Keras model
 
-        :param model_or_file_path: KerasModel or str, either a Keras model or the file path name to one
+        :param model_or_file_path: KerasModel or str, either a Keras model or the file path name
+        to one
         """
         if isinstance(model_or_file_path, KerasModel):
             model = model_or_file_path

--- a/python/sparkdl/graph/builder.py
+++ b/python/sparkdl/graph/builder.py
@@ -90,9 +90,9 @@ class IsolatedSession(object):
             gdef = tfx.strip_and_freeze_until(outputs, self.graph, self.sess)
         else:
             gdef = self.graph.as_graph_def(add_shapes=True)
-        return GraphFunction(graph_def=gdef,
-                             input_names=[tfx.validated_input(elem, self.graph) for elem in inputs],
-                             output_names=[tfx.validated_output(elem, self.graph) for elem in outputs])
+        input_names = [tfx.validated_input(elem, self.graph) for elem in inputs]
+        output_names = [tfx.validated_output(elem, self.graph) for elem in outputs]
+        return GraphFunction(graph_def=gdef, input_names=input_names, output_names=output_names)
 
     def importGraphFunction(self, gfn, input_map=None, prefix="GFN-IMPORT", **gdef_kargs):
         """
@@ -122,13 +122,11 @@ class IsolatedSession(object):
         input_names = gfn.input_names
         output_names = gfn.output_names
         scope_name = prefix
-        if prefix is not None:
+        if prefix:
             scope_name = prefix.strip()
-            if len(scope_name) > 0:
-                output_names = [
-                    scope_name + '/' + op_name for op_name in gfn.output_names]
-                input_names = [
-                    scope_name + '/' + op_name for op_name in gfn.input_names]
+            if scope_name:
+                output_names = [scope_name + '/' + op_name for op_name in gfn.output_names]
+                input_names = [scope_name + '/' + op_name for op_name in gfn.input_names]
 
         # When importing, provide the original output op names
         tf.import_graph_def(gfn.graph_def,
@@ -219,7 +217,7 @@ class GraphFunction(object):
         :param functions: a list of tuples (scope name, GraphFunction object).
         """
         assert len(functions) >= 1, ("must provide at least one function", functions)
-        if 1 == len(functions):
+        if len(functions) == 1:
             return functions[0]
         # Check against each intermediary layer input output function pairs
         for (scope_in, gfn_in), (scope_out, gfn_out) in zip(functions[:-1], functions[1:]):

--- a/python/sparkdl/graph/input.py
+++ b/python/sparkdl/graph/input.py
@@ -77,7 +77,7 @@ class TFInputGraph(object):
                        inference, i.e. the variables are converted to constants and operations like
                        BatchNormalization_ are converted to be independent of input batch.
 
-                       .. _BatchNormalization: https://www.tensorflow.org/api_docs/python/tf/layers/batch_normalization
+   .. _BatchNormalization: https://www.tensorflow.org/api_docs/python/tf/layers/batch_normalization
 
     :param input_tensor_name_from_signature: dict, signature key names mapped to tensor names.
                                              Please see the example above.

--- a/python/sparkdl/graph/pieces.py
+++ b/python/sparkdl/graph/pieces.py
@@ -55,8 +55,8 @@ def buildSpImageConverter(channelOrder, img_dtype):
         elif img_dtype == 'float32':
             image_float = tf.decode_raw(image_buffer, tf.float32, name="decode_raw")
         else:
-            raise ValueError(
-                'unsupported image data type "%s", currently only know how to handle uint8 and float32' % img_dtype)
+            raise ValueError('''unsupported image data type "%s", currently only know how to 
+            handle uint8 and float32''' % img_dtype)
         image_reshaped = tf.reshape(image_float, shape, name="reshaped")
         image_reshaped = imageIO.fixColorChannelOrdering(channelOrder, image_reshaped)
         image_input = tf.expand_dims(image_reshaped, 0, name="image_input")

--- a/python/sparkdl/graph/pieces.py
+++ b/python/sparkdl/graph/pieces.py
@@ -55,7 +55,7 @@ def buildSpImageConverter(channelOrder, img_dtype):
         elif img_dtype == 'float32':
             image_float = tf.decode_raw(image_buffer, tf.float32, name="decode_raw")
         else:
-            raise ValueError('''unsupported image data type "%s", currently only know how to 
+            raise ValueError('''unsupported image data type "%s", currently only know how to
             handle uint8 and float32''' % img_dtype)
         image_reshaped = tf.reshape(image_float, shape, name="reshaped")
         image_reshaped = imageIO.fixColorChannelOrdering(channelOrder, image_reshaped)

--- a/python/sparkdl/graph/tensorframes_udf.py
+++ b/python/sparkdl/graph/tensorframes_udf.py
@@ -23,7 +23,6 @@ from sparkdl.utils import jvmapi as JVMAPI
 
 logger = logging.getLogger('sparkdl')
 
-# pylint: disable=fixme
 
 def makeGraphUDF(graph, udf_name, fetches, feeds_to_fields_map=None, blocked=False, register=True):
     """

--- a/python/sparkdl/graph/tensorframes_udf.py
+++ b/python/sparkdl/graph/tensorframes_udf.py
@@ -16,13 +16,14 @@
 
 import logging
 
-import tensorframes as tfs
+import tensorframes as tfs  # pylint: disable=import-error
 
 import sparkdl.graph.utils as tfx
 from sparkdl.utils import jvmapi as JVMAPI
 
 logger = logging.getLogger('sparkdl')
 
+# pylint: disable=fixme
 
 def makeGraphUDF(graph, udf_name, fetches, feeds_to_fields_map=None, blocked=False, register=True):
     """
@@ -85,6 +86,8 @@ def makeGraphUDF(graph, udf_name, fetches, feeds_to_fields_map=None, blocked=Fal
     placeholder_names = []
     placeholder_shapes = []
     for node in graph.as_graph_def(add_shapes=True).node:
+        # pylint: disable=len-as-condition
+        # todo: refactor if not(node.input) and ...
         if len(node.input) == 0 and str(node.op) == 'Placeholder':
             tnsr_name = tfx.tensor_name(node.name, graph)
             tnsr = graph.get_tensor_by_name(tnsr_name)

--- a/python/sparkdl/graph/utils.py
+++ b/python/sparkdl/graph/utils.py
@@ -15,8 +15,8 @@
 #
 
 import logging
-import six
 
+import six
 import tensorflow as tf
 
 logger = logging.getLogger('sparkdl')
@@ -74,7 +74,7 @@ def get_op(tfobj_or_name, graph):
     if not isinstance(name, six.string_types):
         raise TypeError('invalid op request for [type {}] {}'.format(type(name), name))
     _op_name = op_name(name, graph=None)
-    op = graph.get_operation_by_name(_op_name)
+    op = graph.get_operation_by_name(_op_name)  # pylint: disable=invalid-name
     err_msg = 'cannot locate op {} in the current graph, got [type {}] {}'
     assert isinstance(op, tf.Operation), err_msg.format(_op_name, type(op), op)
     return op
@@ -190,9 +190,8 @@ def validated_input(tfobj_or_name, graph):
     """
     graph = validated_graph(graph)
     name = op_name(tfobj_or_name, graph)
-    op = graph.get_operation_by_name(name)
-    assert 'Placeholder' == op.type, \
-        ('input must be Placeholder, but get', op.type)
+    op = graph.get_operation_by_name(name)  # pylint: disable=invalid-name
+    assert 'Placeholder' == op.type, ('input must be Placeholder, but get', op.type)
     return name
 
 
@@ -223,7 +222,7 @@ def strip_and_freeze_until(fetches, graph, sess=None, return_graph=False):
         sess.close()
 
     if return_graph:
-        g = tf.Graph()
+        g = tf.Graph()  # pylint: disable=invalid-name
         with g.as_default():
             tf.import_graph_def(gdef_frozen, name='')
         return g

--- a/python/sparkdl/image/imageIO.py
+++ b/python/sparkdl/image/imageIO.py
@@ -25,8 +25,7 @@ from pyspark import Row
 from pyspark import SparkContext
 from pyspark.ml.image import ImageSchema
 from pyspark.sql.functions import udf
-from pyspark.sql.types import (
-    BinaryType, IntegerType, StringType, StructField, StructType)
+from pyspark.sql.types import BinaryType, StringType, StructField, StructType
 
 
 # ImageType represents supported OpenCV types
@@ -39,8 +38,7 @@ from pyspark.sql.types import (
 #  NOTE: likely to be migrated to Spark ImageSchema code in the near future.
 _OcvType = namedtuple("OcvType", ["name", "ord", "nChannels", "dtype"])
 
-
-_supportedOcvTypes = (
+_SUPPORTED_OCV_TYPES = (
     _OcvType(name="CV_8UC1", ord=0, nChannels=1, dtype="uint8"),
     _OcvType(name="CV_32FC1", ord=5, nChannels=1, dtype="float32"),
     _OcvType(name="CV_8UC3", ord=16, nChannels=3, dtype="uint8"),
@@ -50,22 +48,22 @@ _supportedOcvTypes = (
 )
 
 #  NOTE: likely to be migrated to Spark ImageSchema code in the near future.
-_ocvTypesByName = {m.name: m for m in _supportedOcvTypes}
-_ocvTypesByOrdinal = {m.ord: m for m in _supportedOcvTypes}
+_OCV_TYPES_BY_NAME = {m.name: m for m in _SUPPORTED_OCV_TYPES}
+_OCV_TYPES_BY_ORDINAL = {m.ord: m for m in _SUPPORTED_OCV_TYPES}
 
 
-def imageTypeByOrdinal(ord):
-    if not ord in _ocvTypesByOrdinal:
+def imageTypeByOrdinal(ordinal):
+    if not ordinal in _OCV_TYPES_BY_ORDINAL:
         raise KeyError("unsupported image type with ordinal %d, supported OpenCV types = %s" % (
-            ord, str(_supportedOcvTypes)))
-    return _ocvTypesByOrdinal[ord]
+            ordinal, str(_SUPPORTED_OCV_TYPES)))
+    return _OCV_TYPES_BY_ORDINAL[ordinal]
 
 
 def imageTypeByName(name):
-    if not name in _ocvTypesByName:
+    if not name in _OCV_TYPES_BY_NAME:
         raise KeyError("unsupported image type with name '%s', supported OpenCV types = %s" % (
-            name, str(_supportedOcvTypes)))
-    return _ocvTypesByName[name]
+            name, str(_SUPPORTED_OCV_TYPES)))
+    return _OCV_TYPES_BY_NAME[name]
 
 
 def imageArrayToStruct(imgArray, origin=""):
@@ -176,6 +174,7 @@ def createResizeImageUDF(size):
     if len(size) != 2:
         raise ValueError(
             "New image size should have format [height, width] but got {}".format(size))
+    # pylint: disable=invalid-name
     sz = (size[1], size[0])
 
     def _resizeImageAsRow(imgAsRow):

--- a/python/sparkdl/image/imageIO.py
+++ b/python/sparkdl/image/imageIO.py
@@ -63,7 +63,7 @@ def imageTypeByOrdinal(ord):
 
 def imageTypeByName(name):
     if not name in _ocvTypesByName:
-        raise KeyError("unsupported image type with name '%s', supported supported OpenCV types = %s" % (
+        raise KeyError("unsupported image type with name '%s', supported OpenCV types = %s" % (
             name, str(_supportedOcvTypes)))
     return _ocvTypesByName[name]
 
@@ -228,11 +228,12 @@ def PIL_decode_and_resize(size):
 
 def readImagesWithCustomFn(path, decode_f, numPartition=None):
     """
-    Read a directory of images (or a single image) into a DataFrame using a custom library to decode the images.
+    Read a directory of images (or a single image) into a DataFrame using a custom library to
+    decode the images.
 
     :param path: str, file path.
-    :param decode_f: function to decode the raw bytes into an array compatible with one of the supported OpenCv modes.
-                 see @imageIO.PIL_decode for an example.
+    :param decode_f: function to decode the raw bytes into an array compatible with one of the
+        supported OpenCv modes. see @imageIO.PIL_decode for an example.
     :param numPartition: [optional] int, number or partitions to use for reading files.
     :return: DataFrame with schema == ImageSchema.imageSchema.
     """

--- a/python/sparkdl/image/imageIO.py
+++ b/python/sparkdl/image/imageIO.py
@@ -149,13 +149,13 @@ def fixColorChannelOrdering(currentOrder, imgAry):
     elif currentOrder == 'BGR':
         return imgAry
     elif currentOrder == 'L':
-        if len(img.shape) != 1:
+        if len(imgAry.shape) != 1:
             raise ValueError(
-                "channel order suggests only one color channel but got shape " + str(img.shape))
+                "channel order suggests only one color channel but got shape " + str(imgAry.shape))
         return imgAry
     else:
         raise ValueError(
-            "Unexpected channel order, expected one of L,RGB,BGR but got " + currentChannelOrder)
+            "Unexpected channel order, expected one of L,RGB,BGR but got " + currentOrder)
 
 
 def _reverseChannels(ary):

--- a/python/sparkdl/image/imageIO.py
+++ b/python/sparkdl/image/imageIO.py
@@ -174,13 +174,12 @@ def createResizeImageUDF(size):
     if len(size) != 2:
         raise ValueError(
             "New image size should have format [height, width] but got {}".format(size))
-    # pylint: disable=invalid-name
-    sz = (size[1], size[0])
+    resize_sizes = (size[1], size[0])
 
     def _resizeImageAsRow(imgAsRow):
-        if (imgAsRow.height, imgAsRow.width) == sz:
+        if (imgAsRow.height, imgAsRow.width) == resize_sizes:
             return imgAsRow
-        imgAsPil = imageStructToPIL(imgAsRow).resize(sz)
+        imgAsPil = imageStructToPIL(imgAsRow).resize(resize_sizes)
         # PIL is RGB based while image schema is BGR based => we need to flip the channels
         imgAsArray = _reverseChannels(np.asarray(imgAsPil))
         return imageArrayToStruct(imgAsArray, origin=imgAsRow.origin)

--- a/python/sparkdl/param/converters.py
+++ b/python/sparkdl/param/converters.py
@@ -170,7 +170,7 @@ class SparkDLTypeConverters(object):
     @staticmethod
     def toChannelOrder(value):
         if not value in ('L', 'RGB', 'BGR'):
-            raise ValueError("""Unsupported channel order. Expected one of ('L', 'RGB', 
+            raise ValueError("""Unsupported channel order. Expected one of ('L', 'RGB',
             'BGR') but got '%s'""" % value)
         return value
 

--- a/python/sparkdl/param/converters.py
+++ b/python/sparkdl/param/converters.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=invalid-name,import-error
-
 """ SparkDLTypeConverters
 
 Type conversion utilities for defining MLlib `Params` used in Spark Deep Learning Pipelines.
@@ -129,7 +127,8 @@ class SparkDLTypeConverters(object):
         Create a "converter" that try to check if a value is part of the supported list of values.
 
         :param supportedList: list, containing supported objects.
-        :return: a converter that try to check if a value is part of the `supportedList` and return it.
+        :return: a converter that try to check if a value is part of the `supportedList` and
+        return it.
                  Raise an error otherwise.
         """
 
@@ -171,8 +170,8 @@ class SparkDLTypeConverters(object):
     @staticmethod
     def toChannelOrder(value):
         if not value in ('L', 'RGB', 'BGR'):
-            raise ValueError(
-                "Unsupported channel order. Expected one of ('L', 'RGB', 'BGR') but got '%s'") % value
+            raise ValueError("""Unsupported channel order. Expected one of ('L', 'RGB', 
+            'BGR') but got '%s'""" % value)
         return value
 
 
@@ -189,8 +188,8 @@ def _check_is_tensor_name(_maybe_tnsr_name):
     #   may optionally be followed by control inputs that have the format
     #   "^node".
     # Reference:
-    #    https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/framework/node_def.proto
-    #    https://stackoverflow.com/questions/36150834/how-does-tensorflow-name-tensors
+    # https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/framework/node_def.proto
+    # https://stackoverflow.com/questions/36150834/how-does-tensorflow-name-tensors
     try:
         _, src_idx = _maybe_tnsr_name.split(":")
         _ = int(src_idx)

--- a/python/sparkdl/param/converters.py
+++ b/python/sparkdl/param/converters.py
@@ -23,12 +23,9 @@ Type conversion utilities for defining MLlib `Params` used in Spark Deep Learnin
 """
 
 import six
-
 import tensorflow as tf
 
-from pyspark.ml.param import TypeConverters
-
-from sparkdl.graph.input import *
+from sparkdl.graph.input import TFInputGraph
 import sparkdl.utils.keras_model as kmutil
 
 __all__ = ['SparkDLTypeConverters']

--- a/python/sparkdl/param/image_params.py
+++ b/python/sparkdl/param/image_params.py
@@ -23,7 +23,7 @@ from pyspark.ml.image import ImageSchema
 from pyspark.ml.param import Param, Params
 from pyspark.sql.functions import udf
 from sparkdl.image.imageIO import _reverseChannels, imageArrayToStruct
-from sparkdl.param import SparkDLTypeConverters
+from sparkdl.param.converters import SparkDLTypeConverters
 
 OUTPUT_MODES = ["vector", "image"]
 

--- a/python/sparkdl/param/image_params.py
+++ b/python/sparkdl/param/image_params.py
@@ -38,7 +38,8 @@ class CanLoadImage(Params):
     This parameter allows users to specify such an image loading function.
     When using inside a pipeline stage, calling this function on an input DataFrame
     will load each image from the image URI column, encode the image in
-    our :py:obj:`~sparkdl.imageIO.imageSchema` format and store it in the :py:meth:`~_loadedImageCol` column.
+    our :py:obj:`~sparkdl.imageIO.imageSchema` format and store it in the
+    :py:meth:`~_loadedImageCol` column.
 
     Below is an example ``image_loader`` function to load Xception https://arxiv.org/abs/1610.02357
     compatible images.
@@ -58,10 +59,13 @@ class CanLoadImage(Params):
             return img_tnsr
     """
 
-    imageLoader = Param(Params._dummy(), "imageLoader",
-                        "Function containing the logic for loading and pre-processing images. " +
-                        "The function should take in a URI string and return a 4-d numpy.array " +
-                        "with shape (batch_size (1), height, width, num_channels). Expected to return result with color channels in RGB order.")
+    imageLoader = Param(
+        Params._dummy(),
+        "imageLoader",
+        """Function containing the logic for loading and pre-processing images. The function 
+        should take in a URI string and return a 4-d numpy.array with shape (batch_size (1), 
+        height, width, num_channels). Expected to return result with color channels in RGB 
+        order.""")
 
     def setImageLoader(self, value):
         return self._set(imageLoader=value)
@@ -92,11 +96,12 @@ class CanLoadImage(Params):
 
 class HasOutputMode(Params):
     # TODO: docs
-    outputMode = Param(Params._dummy(), "outputMode",
-                       "How the output column should be formatted. 'vector' for a 1-d MLlib " +
-                       "Vector of floats. 'image' to format the output to work with the image " +
-                       "tools in this package.",
-                       typeConverter=SparkDLTypeConverters.buildSupportedItemConverter(OUTPUT_MODES))
+    outputMode = Param(
+        Params._dummy(),
+        "outputMode",
+        """How the output column should be formatted. 'vector' for a 1-d MLlib Vector of floats. 
+        'image' to format the output to work with the image tools in this package.""",
+        typeConverter=SparkDLTypeConverters.buildSupportedItemConverter(OUTPUT_MODES))
 
     def __init__(self):
         super(HasOutputMode, self).__init__()

--- a/python/sparkdl/param/image_params.py
+++ b/python/sparkdl/param/image_params.py
@@ -27,7 +27,6 @@ from sparkdl.param.converters import SparkDLTypeConverters
 
 OUTPUT_MODES = ["vector", "image"]
 
-# pylint: disable=fixme
 
 class CanLoadImage(Params):
     """

--- a/python/sparkdl/param/image_params.py
+++ b/python/sparkdl/param/image_params.py
@@ -62,9 +62,9 @@ class CanLoadImage(Params):
     imageLoader = Param(
         Params._dummy(),
         "imageLoader",
-        """Function containing the logic for loading and pre-processing images. The function 
-        should take in a URI string and return a 4-d numpy.array with shape (batch_size (1), 
-        height, width, num_channels). Expected to return result with color channels in RGB 
+        """Function containing the logic for loading and pre-processing images. The function
+        should take in a URI string and return a 4-d numpy.array with shape (batch_size (1),
+        height, width, num_channels). Expected to return result with color channels in RGB
         order.""")
 
     def setImageLoader(self, value):
@@ -99,7 +99,7 @@ class HasOutputMode(Params):
     outputMode = Param(
         Params._dummy(),
         "outputMode",
-        """How the output column should be formatted. 'vector' for a 1-d MLlib Vector of floats. 
+        """How the output column should be formatted. 'vector' for a 1-d MLlib Vector of floats.
         'image' to format the output to work with the image tools in this package.""",
         typeConverter=SparkDLTypeConverters.buildSupportedItemConverter(OUTPUT_MODES))
 

--- a/python/sparkdl/param/image_params.py
+++ b/python/sparkdl/param/image_params.py
@@ -20,14 +20,14 @@ private APIs.
 """
 
 from pyspark.ml.image import ImageSchema
-from pyspark.ml.param import Param, Params, TypeConverters
+from pyspark.ml.param import Param, Params
 from pyspark.sql.functions import udf
-from sparkdl.image.imageIO import imageArrayToStruct
-from sparkdl.image.imageIO import _reverseChannels
+from sparkdl.image.imageIO import _reverseChannels, imageArrayToStruct
 from sparkdl.param import SparkDLTypeConverters
 
 OUTPUT_MODES = ["vector", "image"]
 
+# pylint: disable=fixme
 
 class CanLoadImage(Params):
     """
@@ -73,7 +73,7 @@ class CanLoadImage(Params):
     def getImageLoader(self):
         return self.getOrDefault(self.imageLoader)
 
-    def _loadedImageCol(self):
+    def _loadedImageCol(self):  # pylint: disable=no-self-use
         return "__sdl_img"
 
     def loadImagesInternal(self, dataframe, inputCol):

--- a/python/sparkdl/param/shared_params.py
+++ b/python/sparkdl/param/shared_params.py
@@ -27,7 +27,7 @@ from pyspark.ml.param import Param, Params, TypeConverters
 import sparkdl.graph.utils as tfx
 from sparkdl.param.converters import SparkDLTypeConverters
 
-# pylint: disable=fixme, len-as-condition
+# pylint: disable=len-as-condition
 # len-as-condition is ignored because it is used in code copied from pyspark
 
 ########################################################

--- a/python/sparkdl/param/shared_params.py
+++ b/python/sparkdl/param/shared_params.py
@@ -17,18 +17,18 @@ Some parts are copied from pyspark.ml.param.shared and some are complementary
 to pyspark.ml.param. The copy is due to some useful pyspark fns/classes being
 private APIs.
 """
-import textwrap
 from functools import wraps
-import six
+import textwrap
 
-from keras.models import load_model
 import keras.backend as K
+from keras.models import load_model
 
 from pyspark.ml.param import Param, Params, TypeConverters
-
-from sparkdl.graph.input import TFInputGraph
 import sparkdl.graph.utils as tfx
 from sparkdl.param.converters import SparkDLTypeConverters
+
+# pylint: disable=fixme, len-as-condition
+# len-as-condition is ignored because it is used in code copied from pyspark
 
 ########################################################
 # Copied from PySpark for backward compatibility.

--- a/python/sparkdl/transformers/keras_applications.py
+++ b/python/sparkdl/transformers/keras_applications.py
@@ -75,13 +75,13 @@ from sparkdl.transformers.utils import (imageInputPlaceholder, InceptionV3Consta
 from sparkdl.image.imageIO import _reverseChannels
 
 
-"""
-Essentially a factory function for getting the correct KerasApplicationModel class
-for the network name.
-"""
 
 
 def getKerasApplicationModel(name):
+    """
+    Essentially a factory function for getting the correct KerasApplicationModel class for the
+    network name.
+    """
     try:
         return KERAS_APPLICATION_MODELS[name]()
     except KeyError:

--- a/python/sparkdl/transformers/keras_applications.py
+++ b/python/sparkdl/transformers/keras_applications.py
@@ -94,7 +94,7 @@ class KerasApplicationModel:
 
     def getModelData(self, featurize):
         sess = tf.Session()
-        with sess.as_default():
+        with sess.as_default():     # pylint: disable=not-context-manager
             K.set_learning_phase(0)
             inputImage = imageInputPlaceholder(nChannels=3)
             preprocessed = self.preprocess(inputImage)

--- a/python/sparkdl/transformers/keras_image.py
+++ b/python/sparkdl/transformers/keras_image.py
@@ -58,7 +58,8 @@ class KerasImageFileTransformer(Transformer, HasInputCol, HasOutputCol,
 
     def _transform(self, dataset):
         with KSessionWrap() as (sess, keras_graph):
-            graph, inputTensorName, outputTensorName = self._loadTFGraph(sess=sess, graph=keras_graph)
+            graph, inputTensorName, outputTensorName = self._loadTFGraph(sess=sess,
+                                                                         graph=keras_graph)
             image_df = self.loadImagesInternal(dataset, self.getInputCol())
             transformer = TFImageTransformer(channelOrder='RGB', inputCol=self._loadedImageCol(),
                                              outputCol=self.getOutputCol(), graph=graph,

--- a/python/sparkdl/transformers/keras_image.py
+++ b/python/sparkdl/transformers/keras_image.py
@@ -19,6 +19,8 @@ from sparkdl.param import CanLoadImage, HasInputCol, HasKerasModel, HasOutputCol
 from sparkdl.transformers.keras_utils import KSessionWrap
 from sparkdl.transformers.tf_image import TFImageTransformer
 
+# pylint: disable=duplicate-code
+
 
 class KerasImageFileTransformer(Transformer, HasInputCol, HasOutputCol,
                                 CanLoadImage, HasKerasModel, HasOutputMode):

--- a/python/sparkdl/transformers/keras_image.py
+++ b/python/sparkdl/transformers/keras_image.py
@@ -14,12 +14,10 @@
 #
 
 from pyspark.ml import Transformer
-
-from sparkdl.param import (
-    keyword_only, HasInputCol, HasOutputCol,
-    CanLoadImage, HasKerasModel, HasOutputMode)
-from sparkdl.transformers.tf_image import TFImageTransformer
+from sparkdl.param import CanLoadImage, HasInputCol, HasKerasModel, HasOutputCol, HasOutputMode, \
+    keyword_only
 from sparkdl.transformers.keras_utils import KSessionWrap
+from sparkdl.transformers.tf_image import TFImageTransformer
 
 
 class KerasImageFileTransformer(Transformer, HasInputCol, HasOutputCol,

--- a/python/sparkdl/transformers/keras_tensor.py
+++ b/python/sparkdl/transformers/keras_tensor.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from sparkdl.param import keyword_only, HasKerasModel, HasInputCol, HasOutputCol
-
 from pyspark.ml import Transformer
-
-from sparkdl.transformers.keras_utils import KSessionWrap
 from sparkdl.graph.input import TFInputGraph
+from sparkdl.param import HasInputCol, HasKerasModel, HasOutputCol, keyword_only
+from sparkdl.transformers.keras_utils import KSessionWrap
 from .tf_tensor import TFTransformer
 
 

--- a/python/sparkdl/transformers/keras_tensor.py
+++ b/python/sparkdl/transformers/keras_tensor.py
@@ -18,6 +18,8 @@ from sparkdl.param import HasInputCol, HasKerasModel, HasOutputCol, keyword_only
 from sparkdl.transformers.keras_utils import KSessionWrap
 from .tf_tensor import TFTransformer
 
+# pylint: disable=duplicate-code
+
 
 class KerasTransformer(Transformer, HasInputCol, HasOutputCol, HasKerasModel):
     """

--- a/python/sparkdl/transformers/keras_utils.py
+++ b/python/sparkdl/transformers/keras_utils.py
@@ -34,7 +34,7 @@ class KSessionWrap():
         self.g = self.requested_graph or tf.Graph()
         self.current_session = tf.Session(graph=self.g)
         K.set_session(self.current_session)
-        return (self.current_session, self.g)
+        return self.current_session, self.g
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         # Restore the previous session

--- a/python/sparkdl/transformers/keras_utils.py
+++ b/python/sparkdl/transformers/keras_utils.py
@@ -17,7 +17,8 @@ import keras.backend as K
 import tensorflow as tf
 
 
-class KSessionWrap():
+# pylint: disable=too-few-public-methods
+class KSessionWrap:
     """
     Runs operations in Keras in an isolated manner: the current graph and the current session
     are not modified by anything done in this block:
@@ -30,9 +31,11 @@ class KSessionWrap():
         self.requested_graph = graph
 
     def __enter__(self):
+        # pylint: disable=attribute-defined-outside-init
         self.old_session = K.get_session()
-        self.g = self.requested_graph or tf.Graph()
+        self.g = self.requested_graph or tf.Graph()     # pylint: disable=invalid-name
         self.current_session = tf.Session(graph=self.g)
+        # pylint: enable=attribute-defined-outside-init
         K.set_session(self.current_session)
         return self.current_session, self.g
 

--- a/python/sparkdl/transformers/named_image.py
+++ b/python/sparkdl/transformers/named_image.py
@@ -94,7 +94,7 @@ class DeepImagePredictor(Transformer, HasInputCol, HasOutputCol):
             modelName=self.getModelName(),
             featurize=False)
         transformed = transformer.transform(dataset)
-        if self.getOrDefault(self.decodePredictions):   # pylint: disable=no-else-return
+        if self.getOrDefault(self.decodePredictions):
             return self._decodeOutputAsPredictions(transformed)
         else:
             return transformed.withColumnRenamed(

--- a/python/sparkdl/transformers/named_image.py
+++ b/python/sparkdl/transformers/named_image.py
@@ -219,13 +219,13 @@ class DeepImageFeaturizer(JavaTransformer, JavaMLReadable, JavaMLWritable):
         self._transfer_params_to_java()
         return self
 
-    def setInputCol(selfs, value):
+    def setInputCol(self, value):
         return self._set(inputCol=value)
 
     def getInputCol(self):
         return self.getOrDefault(self.inputCol)
 
-    def setOutputCol(selfs, value):
+    def setOutputCol(self, value):
         return self._set(outputCol=value)
 
     def getOutputCol(self):

--- a/python/sparkdl/transformers/named_image.py
+++ b/python/sparkdl/transformers/named_image.py
@@ -137,8 +137,8 @@ def _getScaleHintList():
         return []
     return dict(featurizer.scaleHintsJava()).keys()
 
-# pylint: disable=too-few-public-methods
-class _LazyScaleHintConverter:
+
+class _LazyScaleHintConverter:  # pylint: disable=too-few-public-methods
     _sizeHintConverter = None
 
     def __call__(self, value):
@@ -148,10 +148,9 @@ class _LazyScaleHintConverter:
         return self._sizeHintConverter(value)
 
 
-# pylint: disable=useless-super-delegation
 class _DeepImageFeaturizerReader(JavaMLReader):
 
-    def __init__(self, clazz):
+    def __init__(self, clazz):  # pylint: disable=useless-super-delegation
         super(_DeepImageFeaturizerReader, self).__init__(clazz)
 
     @classmethod

--- a/python/sparkdl/transformers/named_image.py
+++ b/python/sparkdl/transformers/named_image.py
@@ -94,7 +94,7 @@ class DeepImagePredictor(Transformer, HasInputCol, HasOutputCol):
             modelName=self.getModelName(),
             featurize=False)
         transformed = transformer.transform(dataset)
-        if self.getOrDefault(self.decodePredictions):
+        if self.getOrDefault(self.decodePredictions):   # pylint: disable=no-else-return
             return self._decodeOutputAsPredictions(transformed)
         else:
             return transformed.withColumnRenamed(
@@ -137,7 +137,7 @@ def _getScaleHintList():
         return []
     return dict(featurizer.scaleHintsJava()).keys()
 
-
+# pylint: disable=too-few-public-methods
 class _LazyScaleHintConverter:
     _sizeHintConverter = None
 
@@ -148,10 +148,9 @@ class _LazyScaleHintConverter:
         return self._sizeHintConverter(value)
 
 
-_scaleHintConverter = _LazyScaleHintConverter()
-
-
+# pylint: disable=useless-super-delegation
 class _DeepImageFeaturizerReader(JavaMLReader):
+
     def __init__(self, clazz):
         super(_DeepImageFeaturizerReader, self).__init__(clazz)
 
@@ -193,7 +192,7 @@ class DeepImageFeaturizer(JavaTransformer, JavaMLReadable, JavaMLWritable):
         "scaleHint",
         "Hint which algorhitm to use for image "
         "resizing",
-        typeConverter=_scaleHintConverter)
+        typeConverter=_LazyScaleHintConverter())
 
     @keyword_only
     def __init__(self, inputCol=None, outputCol=None, modelName=None,

--- a/python/sparkdl/transformers/tf_image.py
+++ b/python/sparkdl/transformers/tf_image.py
@@ -155,7 +155,7 @@ class TFImageTransformer(Transformer, HasInputCol, HasOutputCol, HasOutputMode):
             output_shape = final_graph.get_tensor_by_name(original_output_name).shape
             output_mode = self.getOrDefault(self.outputMode)
             # TODO: support non-1d tensors (return np.array).
-            if output_mode == "image":  # pylint: disable=no-else-return
+            if output_mode == "image":
                 return self._convertOutputToImage(final_df, tfs_output_name, output_shape)
             else:
                 assert output_mode == "vector", "Unknown output mode: %s" % output_mode

--- a/python/sparkdl/transformers/tf_image.py
+++ b/python/sparkdl/transformers/tf_image.py
@@ -19,17 +19,16 @@ import tensorframes as tfs
 
 from pyspark import Row
 from pyspark.ml import Transformer
+from pyspark.ml.image import ImageSchema
 from pyspark.ml.param import Param, Params
 from pyspark.sql.functions import udf
 
 import sparkdl.graph.utils as tfx
 import sparkdl.image.imageIO as imageIO
-from sparkdl.param import (
-    keyword_only, HasInputCol, HasOutputCol, SparkDLTypeConverters, HasOutputMode)
+from sparkdl.param import keyword_only, HasInputCol, HasOutputCol, HasOutputMode
+from sparkdl.param import SparkDLTypeConverters
 import sparkdl.transformers.utils as utils
 import sparkdl.utils.jvmapi as JVMAPI
-
-from pyspark.ml.image import ImageSchema
 
 
 __all__ = ['TFImageTransformer']
@@ -58,27 +57,35 @@ class TFImageTransformer(Transformer, HasInputCol, HasOutputCol, HasOutputMode):
               since a new session is created inside this transformer.
     """
 
-    graph = Param(Params._dummy(), "graph", "A TensorFlow computation graph",
-                  typeConverter=SparkDLTypeConverters.toTFGraph)
-    inputTensor = Param(Params._dummy(), "inputTensor",
-                        "A TensorFlow tensor object or name representing the input image",
-                        typeConverter=SparkDLTypeConverters.toTFTensorName)
-    outputTensor = Param(Params._dummy(), "outputTensor",
-                         "A TensorFlow tensor object or name representing the output",
-                         typeConverter=SparkDLTypeConverters.toTFTensorName)
-    channelOrder = Param(Params._dummy(), "channelOrder",
-                         "Strign specifying the expected color channel order, can be one of L,RGB,BGR",
-                         typeConverter=SparkDLTypeConverters.toChannelOrder)
+    graph = Param(
+        Params._dummy(),
+        "graph",
+        "A TensorFlow computation graph",
+        typeConverter=SparkDLTypeConverters.toTFGraph)
+    inputTensor = Param(
+        Params._dummy(),
+        "inputTensor",
+        "A TensorFlow tensor object or name representing the input image",
+        typeConverter=SparkDLTypeConverters.toTFTensorName)
+    outputTensor = Param(
+        Params._dummy(),
+        "outputTensor",
+        "A TensorFlow tensor object or name representing the output",
+        typeConverter=SparkDLTypeConverters.toTFTensorName)
+    channelOrder = Param(
+        Params._dummy(),
+        "channelOrder",
+        "Strign specifying the expected color channel order, can be one of L,RGB,BGR",
+        typeConverter=SparkDLTypeConverters.toChannelOrder)
 
     @keyword_only
     def __init__(self, channelOrder, inputCol=None, outputCol=None, graph=None,
-                 inputTensor=IMAGE_INPUT_TENSOR_NAME, outputTensor=None,
-                 outputMode="vector"):
+                 inputTensor=IMAGE_INPUT_TENSOR_NAME, outputTensor=None, outputMode="vector"):
         """
         __init__(self, channelOrder, inputCol=None, outputCol=None, graph=None,
-                 inputTensor=IMAGE_INPUT_TENSOR_NAME, outputTensor=None,
-                 outputMode="vector")
-          :param: channelOrder: specify the ordering of the color channel, can be one of RGB, BGR, L (grayscale)
+                 inputTensor=IMAGE_INPUT_TENSOR_NAME, outputTensor=None, outputMode="vector")
+          :param: channelOrder: specify the ordering of the color channel, can be one of RGB,
+          BGR, L (grayscale)
         """
         super(TFImageTransformer, self).__init__()
         kwargs = self._input_kwargs
@@ -88,12 +95,10 @@ class TFImageTransformer(Transformer, HasInputCol, HasOutputCol, HasOutputMode):
 
     @keyword_only
     def setParams(self, channelOrder=None, inputCol=None, outputCol=None, graph=None,
-                  inputTensor=IMAGE_INPUT_TENSOR_NAME, outputTensor=None,
-                  outputMode="vector"):
+                  inputTensor=IMAGE_INPUT_TENSOR_NAME, outputTensor=None, outputMode="vector"):
         """
-        setParams(self, inputCol=None, outputCol=None, graph=None,
-                  inputTensor=IMAGE_INPUT_TENSOR_NAME, outputTensor=None,
-                  outputMode="vector")
+        setParams(self, channelOrder=None, inputCol=None, outputCol=None, graph=None,
+                  inputTensor=IMAGE_INPUT_TENSOR_NAME, outputTensor=None, outputMode="vector")
         """
         kwargs = self._input_kwargs
         return self._set(**kwargs)
@@ -178,8 +183,8 @@ class TFImageTransformer(Transformer, HasInputCol, HasOutputCol, HasOutputMode):
             image_buffer = tf.placeholder(tf.string, [], name="image_buffer")
             # Note: the shape argument is required for tensorframes as it uses a
             # slightly older version of tensorflow.
-            shape = tf.reshape(tf.stack([height, width, num_channels], axis=0), shape=(3,),
-                               name='shape')
+            shape_tensor = tf.stack([height, width, num_channels], axis=0)
+            shape = tf.reshape(shape_tensor, shape=(3, ), name='shape')
             if dtype == "uint8":
                 image_uint8 = tf.decode_raw(image_buffer, tf.uint8, name="decode_raw")
                 image_float = tf.to_float(image_uint8)
@@ -191,14 +196,15 @@ class TFImageTransformer(Transformer, HasInputCol, HasOutputCol, HasOutputMode):
             image_reshaped_expanded = tf.expand_dims(image_reshaped, 0, name="expanded")
 
             # Add on the original graph
-            tf.import_graph_def(gdef, input_map={input_tensor_name: image_reshaped_expanded},
-                                return_elements=[self.getOutputTensor().name],
-                                name=USER_GRAPH_NAMESPACE)
+            tf.import_graph_def(
+                gdef,
+                input_map={input_tensor_name: image_reshaped_expanded},
+                return_elements=[self.getOutputTensor().name],
+                name=USER_GRAPH_NAMESPACE)
 
             # Flatten the output for tensorframes
             output_node = g.get_tensor_by_name(self._getOriginalOutputTensorName())
-            _ = tf.reshape(output_node[0],  # batch-size = 1,
-                           shape=[-1], name=self._getFinalOutputOpName())
+            _ = tf.reshape(output_node[0], shape=[-1], name=self._getFinalOutputOpName())
         return g
 
     # Sometimes the tf graph contains a bunch of stuff that doesn't lead to the
@@ -230,18 +236,23 @@ class TFImageTransformer(Transformer, HasInputCol, HasOutputCol, HasOutputMode):
             mode = imageIO.imageTypeByName('CV_32FC%d' % orig_image.nChannels)
             data = bytearray(np.array(numeric_data).astype(np.float32).tobytes())
             nChannels = orig_image.nChannels
-            return Row(origin="", mode=mode.ord, height=height,
-                       width=width, nChannels=nChannels, data=data)
+            return Row(
+                origin="",
+                mode=mode.ord,
+                height=height,
+                width=width,
+                nChannels=nChannels,
+                data=data)
+
         to_image_udf = udf(to_image, ImageSchema.imageSchema['image'].dataType)
-        resDf = df.withColumn(self.getOutputCol(), to_image_udf(
-            df[self.getInputCol()], df[tfs_output_col]))
+        resDf = df.withColumn(self.getOutputCol(),
+                              to_image_udf(df[self.getInputCol()], df[tfs_output_col]))
         return resDf.drop(tfs_output_col)
 
     def _convertOutputToVector(self, df, tfs_output_col):
         """
         Converts the output python list to MLlib Vector.
         """
-        return (
-            df.withColumn(self.getOutputCol(), JVMAPI.listToMLlibVectorUDF(df[tfs_output_col]))
-              .drop(tfs_output_col)
-        )
+        return df\
+            .withColumn(self.getOutputCol(), JVMAPI.listToMLlibVectorUDF(df[tfs_output_col]))\
+            .drop(tfs_output_col)

--- a/python/sparkdl/transformers/tf_image.py
+++ b/python/sparkdl/transformers/tf_image.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 import tensorflow as tf
-import tensorframes as tfs
+import tensorframes as tfs  # pylint: disable=import-error
 
 from pyspark import Row
 from pyspark.ml import Transformer
@@ -37,6 +37,7 @@ IMAGE_INPUT_TENSOR_NAME = tfx.tensor_name(utils.IMAGE_INPUT_PLACEHOLDER_NAME)
 USER_GRAPH_NAMESPACE = 'given'
 NEW_OUTPUT_PREFIX = 'sdl_flattened'
 
+# pylint: disable=fixme
 
 class TFImageTransformer(Transformer, HasInputCol, HasOutputCol, HasOutputMode):
     """
@@ -127,14 +128,14 @@ class TFImageTransformer(Transformer, HasInputCol, HasOutputCol, HasOutputMode):
         graph = self.getGraph()
         composed_graph = self._addReshapeLayers(graph, self._getImageDtype(dataset))
         final_graph = self._stripGraph(composed_graph)
-        with final_graph.as_default():
+        with final_graph.as_default():  # pylint: disable=not-context-manager
             image = dataset[self.getInputCol()]
             image_df_exploded = (dataset
                                  .withColumn("__sdl_image_height", image.height)
                                  .withColumn("__sdl_image_width", image.width)
                                  .withColumn("__sdl_image_nchannels", image.nChannels)
                                  .withColumn("__sdl_image_data", image.data)
-                                 )
+                                )  # yapf: disable
 
             final_output_name = self._getFinalOutputTensorName()
             output_tensor = final_graph.get_tensor_by_name(final_output_name)
@@ -147,14 +148,14 @@ class TFImageTransformer(Transformer, HasInputCol, HasOutputCol, HasOutputMode):
                                  "image_buffer": "__sdl_image_data"})
                 .drop("__sdl_image_height", "__sdl_image_width", "__sdl_image_nchannels",
                       "__sdl_image_data")
-            )
+            )   # yapf: disable
 
             tfs_output_name = tfx.op_name(output_tensor, final_graph)
             original_output_name = self._getOriginalOutputTensorName()
             output_shape = final_graph.get_tensor_by_name(original_output_name).shape
             output_mode = self.getOrDefault(self.outputMode)
             # TODO: support non-1d tensors (return np.array).
-            if output_mode == "image":
+            if output_mode == "image":  # pylint: disable=no-else-return
                 return self._convertOutputToImage(final_df, tfs_output_name, output_shape)
             else:
                 assert output_mode == "vector", "Unknown output mode: %s" % output_mode
@@ -174,8 +175,8 @@ class TFImageTransformer(Transformer, HasInputCol, HasOutputCol, HasOutputMode):
         input_tensor_name = self.getInputTensor().name
 
         gdef = tf_graph.as_graph_def(add_shapes=True)
-        g = tf.Graph()
-        with g.as_default():
+        g = tf.Graph()  # pylint: disable=invalid-name
+        with g.as_default():    # pylint: disable=not-context-manager
             # Flat image data -> image dimensions
             height = tf.placeholder(tf.int32, [], name="height")
             width = tf.placeholder(tf.int32, [], name="width")
@@ -212,8 +213,8 @@ class TFImageTransformer(Transformer, HasInputCol, HasOutputCol, HasOutputMode):
     # are not necessary for the computation at hand.
     def _stripGraph(self, tf_graph):
         gdef = tfx.strip_and_freeze_until([self._getFinalOutputOpName()], tf_graph)
-        g = tf.Graph()
-        with g.as_default():
+        g = tf.Graph()  # pylint: disable=invalid-name
+        with g.as_default():    # pylint: disable=not-context-manager
             tf.import_graph_def(gdef, name='')
         return g
 

--- a/python/sparkdl/transformers/tf_image.py
+++ b/python/sparkdl/transformers/tf_image.py
@@ -37,7 +37,6 @@ IMAGE_INPUT_TENSOR_NAME = tfx.tensor_name(utils.IMAGE_INPUT_PLACEHOLDER_NAME)
 USER_GRAPH_NAMESPACE = 'given'
 NEW_OUTPUT_PREFIX = 'sdl_flattened'
 
-# pylint: disable=fixme
 
 class TFImageTransformer(Transformer, HasInputCol, HasOutputCol, HasOutputMode):
     """

--- a/python/sparkdl/transformers/tf_tensor.py
+++ b/python/sparkdl/transformers/tf_tensor.py
@@ -16,16 +16,17 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import tensorflow as tf
+# pylint: disable=no-name-in-module
 from tensorflow.python.tools import optimize_for_inference_lib as infr_opt
-import tensorframes as tfs
+# pylint: enable=no-name-in-module
+import tensorframes as tfs  # pylint: disable=import-error
 
 from pyspark.ml import Transformer
 from pyspark.sql.types import DoubleType
 
-from sparkdl.graph.builder import GraphFunction
 import sparkdl.graph.utils as tfx
-from sparkdl.param import (keyword_only, HasInputMapping, HasOutputMapping,
-                           HasTFInputGraph, HasTFHParams)
+from sparkdl.param import keyword_only, HasInputMapping, HasOutputMapping, HasTFInputGraph, \
+    HasTFHParams
 
 __all__ = ['TFTransformer']
 
@@ -89,12 +90,12 @@ class TFTransformer(Transformer, HasTFInputGraph, HasTFHParams, HasInputMapping,
                                                placeholder_types)
 
     def _transform(self, dataset):
-        if len([field for field in dataset.schema if field.dataType == DoubleType()]) > 0:
-            logger.warn("Detected DoubleType columns in dataframe passed to transform(). In "
-                        "Deep Learning Pipelines 1.0 and above, DoubleType columns can only be "
-                        "fed to input tensors of type tf.float64. To feed dataframe data to "
-                        "tensors of other types (e.g. tf.float32, tf.int32, tf.int64), use the "
-                        "corresponding Spark SQL data types (FloatType, IntegerType, LongType).")
+        if any([field.dataType == DoubleType() for field in dataset.schema]):
+            logger.warning("Detected DoubleType columns in dataframe passed to transform(). In "
+                           "Deep Learning Pipelines 1.0 and above, DoubleType columns can only be "
+                           "fed to input tensors of type tf.float64. To feed dataframe data to "
+                           "tensors of other types (e.g. tf.float32, tf.int32, tf.int64), use the "
+                           "corresponding Spark SQL data types (FloatType, IntegerType, LongType).")
 
         graph_def = self._optimize_for_inference()
         input_mapping = self.getInputMapping()

--- a/python/sparkdl/transformers/utils.py
+++ b/python/sparkdl/transformers/utils.py
@@ -25,13 +25,13 @@ def imageInputPlaceholder(nChannels=None):
                           name=IMAGE_INPUT_PLACEHOLDER_NAME)
 
 
-class ImageNetConstants:
+class ImageNetConstants:    # pylint: disable=too-few-public-methods
     NUM_CLASSES = 1000
 
 # InceptionV3 is used in a lot of tests, so we'll make this shortcut available
 # For other networks, see the keras_applications module.
 
 
-class InceptionV3Constants:
+class InceptionV3Constants:     # pylint: disable=too-few-public-methods
     INPUT_SHAPE = (299, 299)
     NUM_OUTPUT_FEATURES = 131072

--- a/python/sparkdl/udf/keras_image_model.py
+++ b/python/sparkdl/udf/keras_image_model.py
@@ -16,14 +16,12 @@
 
 import logging
 
-from sparkdl.graph.builder import GraphFunction, IsolatedSession
-from sparkdl.graph.pieces import buildSpImageConverter, buildFlattener
-from sparkdl.graph.tensorframes_udf import makeGraphUDF
-from sparkdl.utils import jvmapi as JVMAPI
-
-import sparkdl.image.imageIO as imageIO
-
 from pyspark.ml.image import ImageSchema
+from sparkdl.graph.builder import GraphFunction, IsolatedSession
+from sparkdl.graph.pieces import buildFlattener, buildSpImageConverter
+from sparkdl.graph.tensorframes_udf import makeGraphUDF
+import sparkdl.image.imageIO as imageIO
+from sparkdl.utils import jvmapi as JVMAPI
 
 logger = logging.getLogger('sparkdl')
 
@@ -80,7 +78,8 @@ def registerKerasImageUDF(udf_name, keras_model_or_file_path, preprocessor=None)
     a (struct) column encoded in [sparkdl.image.imageIO.imageSchema].
     The output will be a single (struct) column containing the resulting tensor data.
 
-    :param udf_name: str, name of the UserDefinedFunction. If the name exists, it will be overwritten.
+    :param udf_name: str, name of the UserDefinedFunction. If the name exists, it will be
+    overwritten.
     :param keras_model_or_file_path: str or KerasModel,
                                      either a path to the HDF5 Keras model file
                                      or an actual loaded Keras model
@@ -134,6 +133,7 @@ def _serialize_and_reload_with(preprocessor):
                          (image_file_path => image_tensor)
     :return: the UDF preprocessor implementation
     """
+
     def udf_impl(spimg):
         import numpy as np
         from tempfile import NamedTemporaryFile

--- a/python/sparkdl/utils/jvmapi.py
+++ b/python/sparkdl/utils/jvmapi.py
@@ -27,7 +27,7 @@ logger = logging.getLogger('sparkdl')
 
 def _curr_sql_ctx(sqlCtx=None):
     _sql_ctx = sqlCtx if sqlCtx is not None else SQLContext._instantiatedContext
-    logger.info("Spark SQL Context = " + str(_sql_ctx))
+    logger.info("Spark SQL Context = %s", _sql_ctx)
     return _sql_ctx
 
 


### PR DESCRIPTION
In this PR, we
* add `python/.pylint/suggested.rc` adapted from the default configuration generated by pylint
* allow both `camelCase` and `snake_case` using regexes lifted from [pylint source code](https://github.com/PyCQA/pylint/blob/master/pylint/checkers/base.py)
* increase thresholds for number of arguments, local, variables
* disable checks that are used often in this project: `unused-argument, too-many-arguments, no-member, missing-docstring, no-init, protected-access, misplaced-comparison-constant, no-else-return, fixme`
* escape some code with `# pylint: disable=...` because it was hard to refactor without thorough testing

Some style decisions that were discussed are:

* disables are acceptable if there is no other way to do this, in which case a comment must be left explaining that
* other disables should be removed and should be considered similar to `todo`s
* we allow `todo` marks in code because these are acceptable for this project and should be taken care of in future
* there are 50 todos, fixmes or pylint disables currently, we should aim to bring this down
  `find python/sparkdl | grep ".*\.py$" | xargs egrep -ino --color=auto "(TODO|FIXME|# pylint).*"`
* function calls and function defintions that span more than 1 line are left to committer and reviewer's discretion
  - pep8 style:
  ```
  long_function_name(
      long_argument_one = "one",
      long_argument_two = "two",
      long_argument_three = "three",
      long_argument_four = "four",
      long_argument_five = "five")
  ```
  - MLlib style:
  ```
  long_function_name(
      long_argument_one = "one", long_argument_two = "two", long_argument_three = "three",
      long_argument_four = "four", long_argument_five = "five")
  ```


