### PR TITLE
Fix type error in TFTransformer example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,9 @@ samples_1 = [np.random.randn(2) + center_1 for _ in range(n_sample//2)]
 labels_1 = [1 for _ in range(n_sample//2)]
 
 rows = map(to_row, zip(map(lambda x: x.tolist(), samples_0 + samples_1), labels_0 + labels_1))
-sdf = spark.createDataFrame(rows)
+schema = StructType([StructField("inputCol", ArrayType(FloatType())),
+                     StructField("label", LongType())])
+sdf = spark.createDataFrame(rows, schema)
 
 ```
 


### PR DESCRIPTION
Fixes the following Exception that occurs when running ```odf = transformer.transform(sdf)``` with Apache Spark 2.3.0, Scala 2.11 from Databricks

```java.lang.Exception: The type of node &apos;input_tensor&apos; (ScalarDoubleType) is not compatible with the data type of the column (ScalarFloatType)```

