### PR TITLE
ignore nullable in DeepImageFeaturizer.validateSchema

### DIFF
--- a/src/main/scala/com/databricks/sparkdl/DeepImageFeaturizer.scala
+++ b/src/main/scala/com/databricks/sparkdl/DeepImageFeaturizer.scala
@@ -25,12 +25,11 @@ import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.param.{Param, ParamMap}
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
 import org.apache.spark.sql.functions.{col, udf}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{DataTypeShim, StructType}
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.tensorflow.framework.GraphDef
 import org.tensorframes.impl.DebugRowOps
 import org.tensorframes.{Shape, ShapeDescription}
-
 
 
 class DeepImageFeaturizer(override val uid: String) extends Transformer with DefaultParamsWritable {
@@ -65,7 +64,7 @@ class DeepImageFeaturizer(override val uid: String) extends Transformer with Def
     val fieldIndex = schema.fieldIndex(inputColumnName)
     val colType = schema.fields(fieldIndex).dataType
     require(
-      colType == ImageSchema.columnSchema,
+      DataTypeShim.equalsIgnoreNullability(colType, ImageSchema.columnSchema),
       s"inputCol must be an image column with schema ImageSchema.columnSchema, got ${colType}"
     )
   }

--- a/src/main/scala/org/apache/spark/sql/types/DataTypeShim.scala
+++ b/src/main/scala/org/apache/spark/sql/types/DataTypeShim.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Databricks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types
+
+object DataTypeShim {
+  /**
+   * Compares two types, ignoring nullability of ArrayType, MapType, StructType.
+   */
+  def equalsIgnoreNullability(left: DataType, right: DataType): Boolean = {
+    DataType.equalsIgnoreNullability(left, right)
+  }
+}

--- a/src/test/scala/com/databricks/sparkdl/DeepImageFeaturizerSuite.scala
+++ b/src/test/scala/com/databricks/sparkdl/DeepImageFeaturizerSuite.scala
@@ -128,4 +128,19 @@ class DeepImageFeaturizerSuite extends FunSuite with TestSparkContext with Defau
       .setOutputCol("myOutput")
     testDefaultReadWrite(featurizer)
   }
+
+  test("DeepImageFeaturizer accepts nullable") {
+    val nullableImageSchema = StructType(
+      data.schema("image").dataType.asInstanceOf[StructType]
+        .fields.map(_.copy(nullable = true)))
+    val nullableSchema = StructType(StructField("image", nullableImageSchema, true) :: Nil)
+    println(nullableSchema)
+    val featurizer = new DeepImageFeaturizer()
+      .setModelName("_test")
+      .setInputCol("image")
+      .setOutputCol("features")
+    withClue("featurizer should accept nullable schemas") {
+      featurizer.transformSchema(nullableSchema)
+    }
+  }
 }

--- a/src/test/scala/com/databricks/sparkdl/DeepImageFeaturizerSuite.scala
+++ b/src/test/scala/com/databricks/sparkdl/DeepImageFeaturizerSuite.scala
@@ -134,7 +134,6 @@ class DeepImageFeaturizerSuite extends FunSuite with TestSparkContext with Defau
       data.schema("image").dataType.asInstanceOf[StructType]
         .fields.map(_.copy(nullable = true)))
     val nullableSchema = StructType(StructField("image", nullableImageSchema, true) :: Nil)
-    println(nullableSchema)
     val featurizer = new DeepImageFeaturizer()
       .setModelName("_test")
       .setInputCol("image")


### PR DESCRIPTION
In Spark SQL, nullability is a hint used during optimization and codegen to skip nullchecks, but not intended as an enforcement mechanism or as an implication that null values do exist. It might get dropped through the pipeline.

This PR switches to `DataType.equalsIgnoreNullability` for the check. Without the change, the test would fail with:

~~~
[info] - DeepImageFeaturizer accepts nullable *** FAILED ***
[info]   java.lang.ClassCastException: org.apache.spark.sql.types.StructField cannot be cast to org.apache.spark.sql.types.StructType
[info]   at com.databricks.sparkdl.DeepImageFeaturizerSuite$$anonfun$8.apply(DeepImageFeaturizerSuite.scala:134)
[info]   at com.databricks.sparkdl.DeepImageFeaturizerSuite$$anonfun$8.apply(DeepImageFeaturizerSuite.scala:132)
[info]   at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:20)
[info]   at org.scalatest.FunSuiteLike$$anon$1.apply(FunSuiteLike.scala:186)
[info]   at org.scalatest.TestSuite$class.withFixture(TestSuite.scala:196)
[info]   at org.scalatest.FunSuite.withFixture(FunSuite.scala:1560)
[info]   at org.scalatest.FunSuiteLike$class.invokeWithFixture$1(FunSuiteLike.scala:183)
~~~

cc: @jkbradley 