### PR TITLE
Move Scalactic dependency to test only

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging-api" % "2.1.2",
   "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2",
   // Matching scalatest versions from TensorFrames
-  "org.scalactic" %% "scalactic" % "3.0.0",
+  "org.scalactic" %% "scalactic" % "3.0.0" % "test",
   "org.scalatest" %% "scalatest" % "3.0.0" % "test"
 )
 


### PR DESCRIPTION
"org.scalactic" %% "scalactic" should only be needed in the test artifacts.  This PR updates the build file to do that.