### PR TITLE
fix the assembly artifact name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,8 @@ sparkVersion := sparkVer
 
 scalaVersion := scalaVer
 
+name := "spark-deep-learning"
+
 spName := "databricks/spark-deep-learning"
 
 // Don't forget to set the version


### PR DESCRIPTION
The assembly name is currently based on the project dir name. We can define `name` in the sbt file to make it deterministic.

cc: @yogeshg 