### PR TITLE
[ML-5666] Update to tensorflow 1.12, tensorframes 0.6.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ sparkComponents ++= Seq("mllib-local", "mllib", "sql")
 
 // add any Spark Package dependencies using spDependencies.
 // e.g. spDependencies += "databricks/spark-avro:0.1"
-spDependencies += s"databricks/tensorframes:0.5.0-s_$scalaMajorVersion"
+spDependencies += s"databricks/tensorframes:0.6.0-s_$scalaMajorVersion"
 
 
 libraryDependencies ++= Seq(

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,7 +14,7 @@ include:
 
 # These allow the documentation to be updated with newer releases
 # of Spark and Scala.
-SPARKDL_VERSION: 1.3.0
+SPARKDL_VERSION: 1.4.0
 #SCALA_BINARY_VERSION: "2.11"
 #SCALA_VERSION: "2.11.8"
 #SPARK_ISSUE_TRACKER_URL: https://issues.apache.org/jira/browse/SPARK

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
 - h5py=2.8.0
 - pillow=4.1.1
 - cloudpickle=0.5.2
-- tensorflow=1.10.0
+- tensorflow=1.12.0
 - keras=2.2.4
 - paramiko=2.4.1
 - wrapt=1.10.11

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,7 +6,7 @@ nose>=1.3.7  # for testing
 parameterized>=0.6.1 # for testing
 pillow>=4.1.1,<4.2
 pygments>=2.2.0
-tensorflow==1.10.0 # NOTE: this package has only been tested with tensorflow 1.10.0
+tensorflow==1.12.0 # NOTE: This package has only been tested with this TensorFlow version.
 pandas>=0.19.1
 six>=1.10.0
 paramiko>=2.4.0

--- a/python/sparkdl/graph/input.py
+++ b/python/sparkdl/graph/input.py
@@ -304,8 +304,7 @@ def _from_saved_model_impl(saved_model_dir, tag_set, signature_def_key, feed_nam
         meta_graph_def = tf.saved_model.loader.load(sess, tag_sets, saved_model_dir)
 
         if signature_def_key is not None:
-            sig_def = tf.contrib.saved_model.get_signature_def_by_key(meta_graph_def,
-                                                                      signature_def_key)
+            sig_def = meta_graph_def.signature_def[signature_def_key]
             return _build_with_sig_def(sess=sess, graph=graph, sig_def=sig_def)
         else:
             return _build_with_feeds_fetches(sess=sess, graph=graph, feed_names=feed_names,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.1-SNAPSHOT"
+version in ThisBuild := "1.4.0-SNAPSHOT"


### PR DESCRIPTION
* Upgrade TF to 1.12.
* TensorFrames 0.6.0 release is compiled with TensorFlow 1.12.
* get_signature_def_by_key is removed in TF 1.12. See https://github.com/tensorflow/tensorflow/releases/tag/v1.12.0. Replaced it with `meta_graph_def.signature_def[signature_def_key]`