### PR TITLE
[ML-5678] Use `conda activate` in docker for best compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ env:
 services:
   - docker
 
+cache:
+  directories:
+  - $HOME/.ivy2/
+
 before_install:
   # update docker compose to the specified version, https://docs.travis-ci.com/user/docker/#using-docker-compose
   - sudo rm /usr/local/bin/docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
 install :
   - docker-compose build --build-arg PYTHON_VERSION=$PYTHON_VERSION
   - docker-compose up -d --scale worker=2
-  - docker-compose exec master bash -c "cd /mnt/sparkdl && build/sbt assembly"
+  - docker-compose exec master bash -i -c "build/sbt assembly"
 
 script:
-  - docker-compose exec master bash -c "cd /mnt/sparkdl && dev/run.py $TEST_SUITE"
+  - docker-compose exec master bash -i -c "dev/run.py $TEST_SUITE"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,15 +5,16 @@ services:
     hostname: master
     environment:
       - MASTER=spark://master:7077
-    entrypoint: bash -c "service ssh restart && spark-class org.apache.spark.deploy.master.Master -h master"
+    entrypoint: bash -i -c "service ssh restart && spark-class org.apache.spark.deploy.master.Master -h master"
     ports:
     - "4040:4040" # driver UI
     - "8080:8080" # master UI
     volumes:
     - .:/mnt/sparkdl
+    - ~/.ivy2:/root/.ivy2
   worker:
     build: .
-    entrypoint: bash -c "service ssh restart && spark-class org.apache.spark.deploy.worker.Worker spark://master:7077"
+    entrypoint: bash -i -c "service ssh restart && spark-class org.apache.spark.deploy.worker.Worker spark://master:7077"
     ports:
     - "8081-8090:8081" # worker UI
     links:


### PR DESCRIPTION
Use "conda activate" for the best compatibility with conda. This PR also made the following changes:

1. Set /mnt/sparkdl as the WORKDIR in Docker.
2. Mount ~/.ivy2 to accelerate sbt build in docker.