### PR TITLE
[ML-5603] remove tests resources from release jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,6 +97,8 @@ includeFilter in unmanagedResources := "requirements.txt" ||
 
 unmanagedResourceDirectories in Test += baseDirectory.value / "python" / "tests"
 
+includeFilter in (Test, unmanagedResources) := AllPassFilter
+
 // Reset mappings in spPackage to avoid including duplicate files.
 mappings in (Compile, spPackage) := (mappings in (Compile, packageBin)).value
 

--- a/build.sbt
+++ b/build.sbt
@@ -92,8 +92,10 @@ unmanagedResources in Compile += baseDirectory.value / "LICENSE"
 unmanagedResourceDirectories in Compile += baseDirectory.value / "python"
 
 includeFilter in unmanagedResources := "requirements.txt" ||
-  new SimpleFileFilter(_.relativeTo(baseDirectory.value / "python")
-    .exists(_.getPath.matches("sparkdl/.*\\.py"))) || "*.png" || "*.jpg" || "*.pb"
+  new SimpleFileFilter(
+    _.relativeTo(baseDirectory.value / "python" / "sparkdl").exists(_.getPath.endsWith(".py")))
+
+unmanagedResourceDirectories in Test += baseDirectory.value / "python" / "tests"
 
 // Reset mappings in spPackage to avoid including duplicate files.
 mappings in (Compile, spPackage) := (mappings in (Compile, packageBin)).value
@@ -110,3 +112,5 @@ releaseProcess := Seq[ReleaseStep](
 
 // Skip tests during assembly
 test in assembly := {}
+
+assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)

--- a/build.sbt
+++ b/build.sbt
@@ -92,12 +92,9 @@ unmanagedResources in Compile += baseDirectory.value / "LICENSE"
 unmanagedResourceDirectories in Compile += baseDirectory.value / "python"
 
 includeFilter in unmanagedResources := "requirements.txt" ||
-  new SimpleFileFilter(
-    _.relativeTo(baseDirectory.value / "python" / "sparkdl").exists(_.getPath.endsWith(".py")))
-
-unmanagedResourceDirectories in Test += baseDirectory.value / "python" / "tests"
-
-includeFilter in (Test, unmanagedResources) := AllPassFilter
+   new SimpleFileFilter(
+     _.relativeTo(baseDirectory.value / "python")
+       .forall(_.getPath.matches("^sparkdl/.*\\.py$")))
 
 // Reset mappings in spPackage to avoid including duplicate files.
 mappings in (Compile, spPackage) := (mappings in (Compile, packageBin)).value


### PR DESCRIPTION
Currently the release jar contains test resources and scala library, which makes the release jar very large and error-prone. This PR removes test resources and scala from the release jar.

It reduces the release jar from 7MB to 230KB.