### PR TITLE
[ML-5968] Update publishing dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,5 +113,3 @@ releaseProcess := Seq[ReleaseStep](
 test in assembly := {}
 
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
-
-credentials += Credentials(Path.userHome / ".spark-packages-credential")

--- a/build.sbt
+++ b/build.sbt
@@ -113,3 +113,5 @@ releaseProcess := Seq[ReleaseStep](
 test in assembly := {}
 
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
+
+credentials += Credentials(Path.userHome / ".spark-packages-credential")

--- a/dev/release.py
+++ b/dev/release.py
@@ -9,7 +9,7 @@ DATABRICKS_REMOTE = "git@github.com:databricks/spark-deep-learning.git"
 PUBLISH_MODES = {
     "local": "publishLocal",
     "m2": "publishM2",
-    "spark-package-publish": "spPublish",
+    "spark-package-publish": "spDist",
 }
 PUBLISH_DOCS_DEFAULT = True
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 // You may use this file to add plugin dependencies for sbt.
 resolvers += "Spark Packages repo" at "https://dl.bintray.com/spark-packages/maven/"
-addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.5")
+addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.6")
 // scalacOptions in (Compile,doc) := Seq("-groups", "-implicits")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 


### PR DESCRIPTION
Use spDist with manual upload to publish instead of spPublish because the upload step of spDist is flaky.