### PR TITLE
remove pyyaml from test requirements

### DIFF
--- a/dev/dev-requirements.txt
+++ b/dev/dev-requirements.txt
@@ -3,4 +3,3 @@ argcomplete==1.9.4
 pylint==1.8.4
 prospector==0.12.7
 yapf==0.21.0
-PyYAML==3.13

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,6 @@ dependencies:
 - parameterized=0.6.1
 - pylint=1.8.4
 - argcomplete=1.9.4
-- PyYAML=3.13
 - pip:
   # runtime
   - horovod==0.15.0


### PR DESCRIPTION
It is not needed and it has security vulnerability.